### PR TITLE
[72] Remove slather from gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
 gem 'cocoapods'
 gem 'fastlane'
-gem 'slather'
 gem 'xcpretty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,6 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     babosa (1.0.2)
     claide (1.0.2)
-    clamp (0.6.5)
     cocoapods (1.3.1)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
@@ -133,7 +132,6 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_magick (4.5.1)
-    mini_portile2 (2.1.0)
     minitest (5.10.3)
     molinillo (0.5.7)
     multi_json (1.12.2)
@@ -142,8 +140,6 @@ GEM
     nanaimo (0.2.3)
     nap (1.1.0)
     netrc (0.11.0)
-    nokogiri (1.6.8.1)
-      mini_portile2 (~> 2.1.0)
     os (0.9.6)
     plist (3.3.0)
     public_suffix (2.0.5)
@@ -162,12 +158,6 @@ GEM
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
     slack-notifier (1.5.1)
-    slather (2.4.4)
-      CFPropertyList (~> 2.2)
-      activesupport (>= 4.0.2, < 5)
-      clamp (~> 0.6)
-      nokogiri (>= 1.6, < 1.7)
-      xcodeproj (~> 1.4)
     terminal-notifier (1.8.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -197,7 +187,6 @@ PLATFORMS
 DEPENDENCIES
   cocoapods
   fastlane
-  slather
   xcpretty
 
 BUNDLED WITH


### PR DESCRIPTION
Resolves #72 

`Slather` was used for SonarQube which will be replaces by SonarCloud in #71.