### PR TITLE
Update plain text length check for RSA1_5

### DIFF
--- a/JOSESwift/Sources/CryptoImplementation/RSA.swift
+++ b/JOSESwift/Sources/CryptoImplementation/RSA.swift
@@ -60,7 +60,7 @@ fileprivate extension AsymmetricKeyAlgorithm {
         case .RSA1_5:
             // For detailed information about the allowed plain text length for RSAES-PKCS1-v1_5,
             // please refer to the RFC(https://tools.ietf.org/html/rfc3447#section-7.2).
-            return plainText.count < (SecKeyGetBlockSize(publicKey) - 11)
+            return plainText.count <= (SecKeyGetBlockSize(publicKey) - 11)
         }
     }
 


### PR DESCRIPTION
https://tools.ietf.org/html/rfc3447#section-7.2.1

M message to be encrypted, an octet string of length mLen, **where mLen <= k - 11**

It was probably a mistake caused by the step 1 description:

   1. Length checking: If mLen > k - 11, output "message too long" and
      stop.