### PR TITLE
[90] Fix prepare lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,8 +23,8 @@ lane :bump do |options|
   bump_type = options[:type]
   version = options[:version]
 
-  new_version_xcode
-  new_version_podspec
+  new_version_xcode = ""
+  new_version_podspec = ""
 
   case bump_type
   when "major", "minor", "patch"


### PR DESCRIPTION
Turns out the variables do need to be initialized, otherwise fastlane will think they're calls to lanes.