### PR TITLE
JWE init method not visible from the extension

### DIFF
--- a/JOSESwift/Sources/JWE.swift
+++ b/JOSESwift/Sources/JWE.swift
@@ -123,7 +123,7 @@ public struct JWE {
     }
 
     /// Initializes a JWE by providing all of it's five parts. Onyl used during deserialization.
-    private init(header: JWEHeader, encryptedKey: Data, initializationVector: Data, ciphertext: Data, authenticationTag: Data) {
+    fileprivate init(header: JWEHeader, encryptedKey: Data, initializationVector: Data, ciphertext: Data, authenticationTag: Data) {
         self.header = header
         self.encryptedKey = encryptedKey
         self.initializationVector = initializationVector


### PR DESCRIPTION
Hello guys :wave:!
Great job far now!

This init method is called from the _CompactDeserializable_ extension which have no access to this method since Swift 3+.

Should I create an issue rather than PR?