### PR TITLE
Add setters for additional JOSEHeader parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: swift
 os: osx
-osx_image: xcode9.2
+osx_image: xcode10
 env: LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 
 before_install:

--- a/JOSESwift/Sources/JOSEHeader.swift
+++ b/JOSESwift/Sources/JOSEHeader.swift
@@ -66,7 +66,7 @@ public protocol CommonHeaderParameterSpace {
     var jwk: String? { get set }
     var kid: String? { get set }
     var x5u: URL? { get set }
-    var x5c: [String: Any]? { get set }
+    var x5c: [String]? { get set }
     var x5t: String? { get set }
     var x5tS256: String? { get set }
     var typ: String? { get set }

--- a/JOSESwift/Sources/JOSEHeader.swift
+++ b/JOSESwift/Sources/JOSEHeader.swift
@@ -62,14 +62,14 @@ extension JOSEHeader {
 /// JWS and JWE share a common Header Parameter space that both JWS and JWE headers must support.
 /// Those header parameters may have a different meaning depending on whether they are part of a JWE or JWS.
 public protocol CommonHeaderParameterSpace {
-    var jku: URL? { get }
-    var jwk: String? { get }
-    var kid: String? { get }
-    var x5u: URL? { get }
-    var x5c: [String: Any]? { get }
-    var x5t: String? { get }
-    var x5tS256: String? { get }
-    var typ: String? { get }
-    var cty: String? { get }
-    var crit: [String]? { get }
+    var jku: URL? { get set }
+    var jwk: String? { get set }
+    var kid: String? { get set }
+    var x5u: URL? { get set }
+    var x5c: [String: Any]? { get set }
+    var x5t: String? { get set }
+    var x5tS256: String? { get set }
+    var typ: String? { get set }
+    var cty: String? { get set }
+    var crit: [String]? { get set }
 }

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -54,7 +54,8 @@ public struct JWEHeader: JOSEHeader {
         self.parameters = parameters
     }
 
-    /// Initializes a `JWEHeader` with the specified algorithm and signing algorithm.
+    /// Initializes a `JWEHeader` with the specified algorithm, signing algorithm
+    /// and optionally a key identifier.
     public init(algorithm: AsymmetricKeyAlgorithm, encryptionAlgorithm: SymmetricKeyAlgorithm, keyIdentifier: String? = nil) {
         var parameters = [
             "alg": algorithm.rawValue,

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -102,10 +102,13 @@ extension JWEHeader: CommonHeaderParameterSpace {
     /// one of which corresponds to the key used to encrypt the JWE.
     public var jku: URL? {
         set {
-            parameters["jku"] = newValue
+            parameters["jku"] = newValue?.absoluteString
         }
         get {
-            return parameters["jku"] as? URL
+            guard let parameter = parameters["jku"] as? String else {
+                return nil
+            }
+            return URL(string: parameter)
         }
     }
 
@@ -133,10 +136,13 @@ extension JWEHeader: CommonHeaderParameterSpace {
     /// or certificate chain corresponding to the key used to encrypt the JWE.
     public var x5u: URL? {
         set {
-            parameters["x5u"] = newValue
+            parameters["x5u"] = newValue?.absoluteString
         }
         get {
-            return parameters["x5u"] as? URL
+            guard let parameter = parameters["x5u"] as? String else {
+                return nil
+            }
+            return URL(string: parameter)
         }
     }
 

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -54,17 +54,12 @@ public struct JWEHeader: JOSEHeader {
         self.parameters = parameters
     }
 
-    /// Initializes a `JWEHeader` with the specified algorithm, signing algorithm
-    /// and optionally a key identifier.
-    public init(algorithm: AsymmetricKeyAlgorithm, encryptionAlgorithm: SymmetricKeyAlgorithm, keyIdentifier: String? = nil) {
-        var parameters = [
+    /// Initializes a `JWEHeader` with the specified algorithm and signing algorithm.
+    public init(algorithm: AsymmetricKeyAlgorithm, encryptionAlgorithm: SymmetricKeyAlgorithm) {
+        let parameters = [
             "alg": algorithm.rawValue,
             "enc": encryptionAlgorithm.rawValue
         ]
-
-        if let keyIdentifier = keyIdentifier {
-            parameters["kid"] = keyIdentifier
-        }
 
         // Forcing the try is ok here, since [String: String] can be converted to JSON.
         // swiftlint:disable:next force_try

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -28,7 +28,10 @@ public struct JWEHeader: JOSEHeader {
     var headerData: Data
     var parameters: [String: Any] {
         didSet {
-            // Forcing the try is ok here, since [String: String] can be converted to JSON.
+            guard JSONSerialization.isValidJSONObject(parameters) else {
+                return
+            }
+            // Forcing the try is ok here, because it is valid JSON.
             // swiftlint:disable:next force_try
             headerData = try! JSONSerialization.data(withJSONObject: parameters, options: [])
         }

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -142,12 +142,12 @@ extension JWEHeader: CommonHeaderParameterSpace {
 
     /// The X.509 certificate chain contains the X.509 public key certificate or
     /// certificate chain corresponding to the key used to encrypt the JWE.
-    public var x5c: [String: Any]? {
+    public var x5c: [String]? {
         set {
             parameters["x5c"] = newValue
         }
         get {
-            return parameters["x5c"] as? [String: Any]
+            return parameters["x5c"] as? [String]
         }
     }
 

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -25,8 +25,14 @@ import Foundation
 
 /// The header of a `JWE` object.
 public struct JWEHeader: JOSEHeader {
-    let headerData: Data
-    let parameters: [String: Any]
+    var headerData: Data
+    var parameters: [String: Any] {
+        didSet {
+            // Forcing the try is ok here, since [String: String] can be converted to JSON.
+            // swiftlint:disable:next force_try
+            headerData = try! JSONSerialization.data(withJSONObject: parameters, options: [])
+        }
+    }
 
     /// Initializes a JWE header with given parameters and their original `Data` representation.
     /// Note that this (base64-url decoded) `Data` representation has to be exactly as it was
@@ -95,55 +101,105 @@ extension JWEHeader: CommonHeaderParameterSpace {
     /// The JWK Set URL which refers to a resource for a set of JSON-encoded public keys,
     /// one of which corresponds to the key used to encrypt the JWE.
     public var jku: URL? {
-        return parameters["jku"] as? URL
+        set {
+            parameters["jku"] = newValue
+        }
+        get {
+            return parameters["jku"] as? URL
+        }
     }
 
     /// The JSON Web key corresponding to the key used to encrypt the JWE.
     public var jwk: String? {
-        return parameters["jwk"] as? String
+        set {
+            parameters["jwk"] = newValue
+        }
+        get {
+            return parameters["jwk"] as? String
+        }
     }
 
     /// The Key ID indicates the key which was used to encrypt the JWE.
     public var kid: String? {
-        return parameters["kid"] as? String
+        set {
+            parameters["kid"] = newValue
+        }
+        get {
+            return parameters["kid"] as? String
+        }
     }
 
     /// The X.509 URL that referes to a resource for the X.509 public key certificate
     /// or certificate chain corresponding to the key used to encrypt the JWE.
     public var x5u: URL? {
-        return parameters["x5u"] as? URL
+        set {
+            parameters["x5u"] = newValue
+        }
+        get {
+            return parameters["x5u"] as? URL
+        }
     }
 
     /// The X.509 certificate chain contains the X.509 public key certificate or
     /// certificate chain corresponding to the key used to encrypt the JWE.
     public var x5c: [String: Any]? {
-        return parameters["x5c"] as? [String: Any]
+        set {
+            parameters["x5c"] = newValue
+        }
+        get {
+            return parameters["x5c"] as? [String: Any]
+        }
     }
 
     /// The X.509 certificate SHA-1 thumbprint of the DER encoding of the X.509 certificate
     /// corresponding to the key used to encrypt the JWE.
     public var x5t: String? {
-        return parameters["x5t"] as? String
+        set {
+            parameters["x5t"] = newValue
+        }
+        get {
+            return parameters["x5t"] as? String
+        }
     }
 
     /// The X.509 certificate SHA-256 thumbprint of the DER encoding of the X.509 certificate
     /// corresponding to the key used to encrypt the JWE.
     public var x5tS256: String? {
-        return parameters["x5tS256"] as? String
+        set {
+            parameters["x5tS256"] = newValue
+        }
+        get {
+            return parameters["x5tS256"] as? String
+        }
     }
 
     /// The type to declare the media type of the JWE object.
     public var typ: String? {
-        return parameters["typ"] as? String
+        set {
+            parameters["typ"] = newValue
+        }
+        get {
+            return parameters["typ"] as? String
+        }
     }
 
     /// The content type to declare the media type of the secured content (payload).
     public var cty: String? {
-        return parameters["cty"] as? String
+        set {
+            parameters["cty"] = newValue
+        }
+        get {
+            return parameters["cty"] as? String
+        }
     }
 
     /// The critical header parameter indicates the header parameter extensions.
     public var crit: [String]? {
-        return parameters["crit"] as? [String]
+        set {
+            parameters["crit"] = newValue
+        }
+        get {
+            return parameters["crit"] as? [String]
+        }
     }
 }

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -55,11 +55,15 @@ public struct JWEHeader: JOSEHeader {
     }
 
     /// Initializes a `JWEHeader` with the specified algorithm and signing algorithm.
-    public init(algorithm: AsymmetricKeyAlgorithm, encryptionAlgorithm: SymmetricKeyAlgorithm) {
-        let parameters = [
+    public init(algorithm: AsymmetricKeyAlgorithm, encryptionAlgorithm: SymmetricKeyAlgorithm, keyIdentifier: String? = nil) {
+        var parameters = [
             "alg": algorithm.rawValue,
             "enc": encryptionAlgorithm.rawValue
         ]
+
+        if let keyIdentifier = keyIdentifier {
+            parameters["kid"] = keyIdentifier
+        }
 
         // Forcing the try is ok here, since [String: String] can be converted to JSON.
         // swiftlint:disable:next force_try

--- a/JOSESwift/Sources/JWSHeader.swift
+++ b/JOSESwift/Sources/JWSHeader.swift
@@ -127,12 +127,12 @@ extension JWSHeader: CommonHeaderParameterSpace {
 
     /// The X.509 certificate chain contains the X.509 public key certificate or
     /// certificate chain corresponding to the key used to sign the JWS.
-    public var x5c: [String: Any]? {
+    public var x5c: [String]? {
         set {
             parameters["x5c"] = newValue
         }
         get {
-            return parameters["x5c"] as? [String: Any]
+            return parameters["x5c"] as? [String]
         }
     }
 

--- a/JOSESwift/Sources/JWSHeader.swift
+++ b/JOSESwift/Sources/JWSHeader.swift
@@ -25,8 +25,14 @@ import Foundation
 
 /// The header of a `JWS` object.
 public struct JWSHeader: JOSEHeader {
-    let headerData: Data
-    let parameters: [String: Any]
+    var headerData: Data
+    var parameters: [String: Any] {
+        didSet {
+            // Forcing the try is ok here, since [String: String] can be converted to JSON.
+            // swiftlint:disable:next force_try
+            headerData = try! JSONSerialization.data(withJSONObject: parameters, options: [])
+        }
+    }
 
     /// Initializes a JWS header with given parameters and their original `Data` representation.
     /// Note that this (base64-url decoded) `Data` representation has to be exactly as it was
@@ -79,56 +85,105 @@ extension JWSHeader {
 extension JWSHeader: CommonHeaderParameterSpace {
     /// The JWK Set URL which refers to a resource for a set of JSON-encoded public keys,
     /// one of which corresponds to the key used to sign the JWS.
-    public var jku: URL? {
-        return parameters["jku"] as? URL
+    public var jku: URL? {set {
+        parameters["jku"] = newValue
+        }
+        get {
+            return parameters["jku"] as? URL
+        }
     }
 
     /// The JSON Web key corresponding to the key used to digitally sign the JWS.
     public var jwk: String? {
-        return parameters["jwk"] as? String
+        set {
+            parameters["jwk"] = newValue
+        }
+        get {
+            return parameters["jwk"] as? String
+        }
     }
 
     /// The Key ID indicates the key which was used to secure the JWS.
     public var kid: String? {
-        return parameters["kid"] as? String
+        set {
+            parameters["kid"] = newValue
+        }
+        get {
+            return parameters["kid"] as? String
+        }
     }
 
     /// The X.509 URL that referes to a resource for the X.509 public key certificate
     /// or certificate chain corresponding to the key used to sign the JWS.
     public var x5u: URL? {
-        return parameters["x5u"] as? URL
+        set {
+            parameters["x5u"] = newValue
+        }
+        get {
+            return parameters["x5u"] as? URL
+        }
     }
 
     /// The X.509 certificate chain contains the X.509 public key certificate or
     /// certificate chain corresponding to the key used to sign the JWS.
     public var x5c: [String: Any]? {
-        return parameters["x5c"] as? [String: Any]
+        set {
+            parameters["x5c"] = newValue
+        }
+        get {
+            return parameters["x5c"] as? [String: Any]
+        }
     }
 
     /// The X.509 certificate SHA-1 thumbprint of the DER encoding of the X.509 certificate
     /// corresponding to the key used to sign the JWS.
     public var x5t: String? {
-        return parameters["x5t"] as? String
+        set {
+            parameters["x5t"] = newValue
+        }
+        get {
+            return parameters["x5t"] as? String
+        }
     }
 
     /// The X.509 certificate SHA-256 thumbprint of the DER encoding of the X.509 certificate
     /// corresponding to the key used to sign the JWS.
     public var x5tS256: String? {
-        return parameters["jwk"] as? String
+        set {
+            parameters["x5tS256"] = newValue
+        }
+        get {
+            return parameters["x5tS256"] as? String
+        }
     }
 
     /// The type to declare the media type of the JWS object.
     public var typ: String? {
-        return parameters["typ"] as? String
+        set {
+            parameters["typ"] = newValue
+        }
+        get {
+            return parameters["typ"] as? String
+        }
     }
 
     /// The content type to declare the media type of the secured content (payload).
     public var cty: String? {
-        return parameters["cty"] as? String
+        set {
+            parameters["cty"] = newValue
+        }
+        get {
+            return parameters["cty"] as? String
+        }
     }
 
     /// The critical header parameter indicates the header parameter extensions.
     public var crit: [String]? {
-        return parameters["crit"] as? [String]
+        set {
+            parameters["crit"] = newValue
+        }
+        get {
+            return parameters["crit"] as? [String]
+        }
     }
 }

--- a/JOSESwift/Sources/JWSHeader.swift
+++ b/JOSESwift/Sources/JWSHeader.swift
@@ -87,10 +87,13 @@ extension JWSHeader: CommonHeaderParameterSpace {
     /// one of which corresponds to the key used to sign the JWS.
     public var jku: URL? {
         set {
-            parameters["jku"] = newValue
+            parameters["jku"] = newValue?.absoluteString
         }
         get {
-            return parameters["jku"] as? URL
+            guard let parameter = parameters["jku"] as? String else {
+                return nil
+            }
+            return URL(string: parameter)
         }
     }
 
@@ -118,10 +121,13 @@ extension JWSHeader: CommonHeaderParameterSpace {
     /// or certificate chain corresponding to the key used to sign the JWS.
     public var x5u: URL? {
         set {
-            parameters["x5u"] = newValue
+            parameters["x5u"] = newValue?.absoluteString
         }
         get {
-            return parameters["x5u"] as? URL
+            guard let parameter = parameters["x5u"] as? String else {
+                return nil
+            }
+            return URL(string: parameter)
         }
     }
 

--- a/JOSESwift/Sources/JWSHeader.swift
+++ b/JOSESwift/Sources/JWSHeader.swift
@@ -85,8 +85,9 @@ extension JWSHeader {
 extension JWSHeader: CommonHeaderParameterSpace {
     /// The JWK Set URL which refers to a resource for a set of JSON-encoded public keys,
     /// one of which corresponds to the key used to sign the JWS.
-    public var jku: URL? {set {
-        parameters["jku"] = newValue
+    public var jku: URL? {
+        set {
+            parameters["jku"] = newValue
         }
         get {
             return parameters["jku"] as? URL

--- a/JOSESwift/Sources/JWSHeader.swift
+++ b/JOSESwift/Sources/JWSHeader.swift
@@ -28,7 +28,10 @@ public struct JWSHeader: JOSEHeader {
     var headerData: Data
     var parameters: [String: Any] {
         didSet {
-            // Forcing the try is ok here, since [String: String] can be converted to JSON.
+            guard JSONSerialization.isValidJSONObject(parameters) else {
+                return
+            }
+            // Forcing the try is ok here, because it is valid JSON.
             // swiftlint:disable:next force_try
             headerData = try! JSONSerialization.data(withJSONObject: parameters, options: [])
         }

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ let message = "Summer ⛱, Sun ☀️, Cactus 🌵".data(using: .utf8)!
 ```
 
 ``` swift
-let header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512)
+let header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512, keyIdentifier: "your_keyIdentifier")
 
 let payload = Payload(message)
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ let message = "Summer ⛱, Sun ☀️, Cactus 🌵".data(using: .utf8)!
 ```
 
 ``` swift
-let header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512, keyIdentifier: "your_keyIdentifier")
+let header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512)
 
 let payload = Payload(message)
 

--- a/Tests/JWEHeaderTests.swift
+++ b/Tests/JWEHeaderTests.swift
@@ -135,7 +135,7 @@ class JWEHeaderTests: XCTestCase {
         let x5tS256 = "x5tS256"
         let typ = "typ"
         let cty = "cty"
-        let crit = ["crit1", "crit2"]
+        let crit: [String]? = ["crit1", "crit2"]
 
         var header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512)
         header.jku = jku

--- a/Tests/JWEHeaderTests.swift
+++ b/Tests/JWEHeaderTests.swift
@@ -130,7 +130,7 @@ class JWEHeaderTests: XCTestCase {
         let jwk = "jwk"
         let kid = "kid"
         let x5u: URL? = nil
-        let x5c: [String: Any]? = ["":""]
+        let x5c: [String]? = ["key1", "key2"]
         let x5t = "x5t"
         let x5tS256 = "x5tS256"
         let typ = "typ"
@@ -163,8 +163,8 @@ class JWEHeaderTests: XCTestCase {
         XCTAssertEqual(header.parameters["x5u"] as? URL, x5u)
         XCTAssertEqual(header.x5u, x5u)
 
-//        XCTAssertEqual(header.parameters["x5c"] as? [String: Any], x5c)
-//        XCTAssertEqual(header.x5c, x5c)
+        XCTAssertEqual(header.parameters["x5c"] as? [String], x5c)
+        XCTAssertEqual(header.x5c, x5c)
 
         XCTAssertEqual(header.parameters["x5t"] as? String, x5t)
         XCTAssertEqual(header.x5t, x5t)

--- a/Tests/JWEHeaderTests.swift
+++ b/Tests/JWEHeaderTests.swift
@@ -125,15 +125,61 @@ class JWEHeaderTests: XCTestCase {
         XCTFail()
     }
 
-    func testInitWithAlgAndEncAndKid() {
-        let keyIdentifier = "keyIdentifier"
+    func testSetHeaderParameters() {
+        let jku: URL? = nil
+        let jwk = "jwk"
+        let kid = "kid"
+        let x5u: URL? = nil
+        let x5c: [String: Any]? = ["":""]
+        let x5t = "x5t"
+        let x5tS256 = "x5tS256"
+        let typ = "typ"
+        let cty = "cty"
+        let crit = ["crit1", "crit2"]
 
         var header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512)
-        header.kid = keyIdentifier
+        header.jku = jku
+        header.jwk = jwk
+        header.kid = kid
+        header.x5u = x5u
+        header.x5c = x5c
+        header.x5t = x5t
+        header.x5tS256 = x5tS256
+        header.typ = typ
+        header.cty = cty
+        header.crit = crit
 
         XCTAssertEqual(header.data(), try! JSONSerialization.data(withJSONObject: header.parameters, options: []))
-        XCTAssertEqual(header.parameters["kid"] as? String, keyIdentifier)
-        XCTAssertEqual(header.kid, keyIdentifier)
+
+        XCTAssertEqual(header.parameters["jku"] as? URL, jku)
+        XCTAssertEqual(header.jku, jku)
+
+        XCTAssertEqual(header.parameters["jwk"] as? String, jwk)
+        XCTAssertEqual(header.jwk, jwk)
+
+        XCTAssertEqual(header.parameters["kid"] as? String, kid)
+        XCTAssertEqual(header.kid, kid)
+
+        XCTAssertEqual(header.parameters["x5u"] as? URL, x5u)
+        XCTAssertEqual(header.x5u, x5u)
+
+//        XCTAssertEqual(header.parameters["x5c"] as? [String: Any], x5c)
+//        XCTAssertEqual(header.x5c, x5c)
+
+        XCTAssertEqual(header.parameters["x5t"] as? String, x5t)
+        XCTAssertEqual(header.x5t, x5t)
+
+        XCTAssertEqual(header.parameters["x5tS256"] as? String, x5tS256)
+        XCTAssertEqual(header.x5tS256, x5tS256)
+
+        XCTAssertEqual(header.parameters["typ"] as? String, typ)
+        XCTAssertEqual(header.typ, typ)
+
+        XCTAssertEqual(header.parameters["cty"] as? String, cty)
+        XCTAssertEqual(header.cty, cty)
+
+        XCTAssertEqual(header.parameters["crit"] as? [String], crit)
+        XCTAssertEqual(header.crit, crit)
     }
 
 }

--- a/Tests/JWEHeaderTests.swift
+++ b/Tests/JWEHeaderTests.swift
@@ -128,13 +128,10 @@ class JWEHeaderTests: XCTestCase {
     func testInitWithAlgAndEncAndKid() {
         let keyIdentifier = "keyIdentifier"
 
-        //add keyIdentifier to parameterDictRSA
-        var dict = parameterDictRSA
-        dict["kid"] = keyIdentifier
+        var header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512)
+        header.kid = keyIdentifier
 
-        let header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512, keyIdentifier: keyIdentifier)
-
-        XCTAssertEqual(header.data(), try! JSONSerialization.data(withJSONObject: dict, options: []))
+        XCTAssertEqual(header.data(), try! JSONSerialization.data(withJSONObject: header.parameters, options: []))
         XCTAssertEqual(header.parameters["kid"] as? String, keyIdentifier)
         XCTAssertEqual(header.kid, keyIdentifier)
     }

--- a/Tests/JWEHeaderTests.swift
+++ b/Tests/JWEHeaderTests.swift
@@ -125,17 +125,17 @@ class JWEHeaderTests: XCTestCase {
         XCTFail()
     }
 
-    func testSetHeaderParameters() {
+    func testSetNonRequiredHeaderParametersInJWEHeader() {
         let jku: URL? = nil
         let jwk = "jwk"
         let kid = "kid"
         let x5u: URL? = nil
-        let x5c: [String]? = ["key1", "key2"]
+        let x5c = ["key1", "key2"]
         let x5t = "x5t"
         let x5tS256 = "x5tS256"
         let typ = "typ"
         let cty = "cty"
-        let crit: [String]? = ["crit1", "crit2"]
+        let crit = ["crit1", "crit2"]
 
         var header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512)
         header.jku = jku

--- a/Tests/JWEHeaderTests.swift
+++ b/Tests/JWEHeaderTests.swift
@@ -125,4 +125,18 @@ class JWEHeaderTests: XCTestCase {
         XCTFail()
     }
 
+    func testInitWithAlgAndEncAndKid() {
+        let keyIdentifier = "keyIdentifier"
+
+        //add keyIdentifier to parameterDictRSA
+        var dict = parameterDictRSA
+        dict["kid"] = keyIdentifier
+
+        let header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512, keyIdentifier: keyIdentifier)
+
+        XCTAssertEqual(header.data(), try! JSONSerialization.data(withJSONObject: dict, options: []))
+        XCTAssertEqual(header.parameters["kid"] as? String, keyIdentifier)
+        XCTAssertEqual(header.kid, keyIdentifier)
+    }
+
 }

--- a/Tests/JWERSATests.swift
+++ b/Tests/JWERSATests.swift
@@ -52,6 +52,21 @@ class JWETests: CryptoTestCase {
     }
 
     @available(*, deprecated)
+    func testJWERoundtripWithNonRequiredJWEHeaderParameter() {
+        var header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512)
+        header.kid = "kid"
+
+        let payload = Payload(message.data(using: .utf8)!)
+        let encrypter = Encrypter(keyEncryptionAlgorithm: .RSA1_5, encryptionKey: publicKeyAlice2048!, contentEncyptionAlgorithm: .A256CBCHS512)!
+        let jweEnc = try! JWE(header: header, payload: payload, encrypter: encrypter)
+
+        let jweDec = try! JWE(compactSerialization: jweEnc.compactSerializedData)
+        let decryptedPayload = try! jweDec.decrypt(with: privateKeyAlice2048!)
+
+        XCTAssertEqual(message.data(using: .utf8)!, decryptedPayload.data())
+    }
+
+    @available(*, deprecated)
     func testDecryptWithInferredDecrypter() {
         let jwe = try! JWE(compactSerialization: compactSerializedJWE)
         let payload = try! jwe.decrypt(with: privateKeyAlice2048!).data()

--- a/Tests/JWSHeaderTests.swift
+++ b/Tests/JWSHeaderTests.swift
@@ -87,4 +87,61 @@ class JWSHeaderTests: XCTestCase {
         XCTFail()
     }
 
+    func testSetNonRequiredHeaderParametersInJWSHeader() {
+        let jku: URL? = nil
+        let jwk = "jwk"
+        let kid = "kid"
+        let x5u: URL? = nil
+        let x5c = ["key1", "key2"]
+        let x5t = "x5t"
+        let x5tS256 = "x5tS256"
+        let typ = "typ"
+        let cty = "cty"
+        let crit = ["crit1", "crit2"]
+
+        var header = JWSHeader(algorithm: .RS512)
+        header.jku = jku
+        header.jwk = jwk
+        header.kid = kid
+        header.x5u = x5u
+        header.x5c = x5c
+        header.x5t = x5t
+        header.x5tS256 = x5tS256
+        header.typ = typ
+        header.cty = cty
+        header.crit = crit
+
+        XCTAssertEqual(header.data(), try! JSONSerialization.data(withJSONObject: header.parameters, options: []))
+
+        XCTAssertEqual(header.parameters["jku"] as? URL, jku)
+        XCTAssertEqual(header.jku, jku)
+
+        XCTAssertEqual(header.parameters["jwk"] as? String, jwk)
+        XCTAssertEqual(header.jwk, jwk)
+
+        XCTAssertEqual(header.parameters["kid"] as? String, kid)
+        XCTAssertEqual(header.kid, kid)
+
+        XCTAssertEqual(header.parameters["x5u"] as? URL, x5u)
+        XCTAssertEqual(header.x5u, x5u)
+
+        XCTAssertEqual(header.parameters["x5c"] as? [String], x5c)
+        XCTAssertEqual(header.x5c, x5c)
+
+        XCTAssertEqual(header.parameters["x5t"] as? String, x5t)
+        XCTAssertEqual(header.x5t, x5t)
+
+        XCTAssertEqual(header.parameters["x5tS256"] as? String, x5tS256)
+        XCTAssertEqual(header.x5tS256, x5tS256)
+
+        XCTAssertEqual(header.parameters["typ"] as? String, typ)
+        XCTAssertEqual(header.typ, typ)
+
+        XCTAssertEqual(header.parameters["cty"] as? String, cty)
+        XCTAssertEqual(header.cty, cty)
+
+        XCTAssertEqual(header.parameters["crit"] as? [String], crit)
+        XCTAssertEqual(header.crit, crit)
+    }
+
 }

--- a/Tests/JWSTests.swift
+++ b/Tests/JWSTests.swift
@@ -35,16 +35,27 @@ class JWSTests: CryptoTestCase {
 
     @available(*, deprecated)
     func testSignAndSerializeRS256() {
-        self.performTestRSASign(algorithm: .RS256, compactSerializedJWS: compactSerializedJWSRS256Const)
+        self.performTestRSASign(algorithm: .RS256)
+    }
+
+    @available(*, deprecated)
+    func testSignAndVerifyRS256WithNonRequiredHeaderParameter() {
+        self.performTestRSASign(algorithm: .RS256, withKid: true)
     }
 
     func testDeserializeFromCompactSerializationRS256() {
         self.performTestRSADeserialization(algorithm: .RS256, compactSerializedJWS: compactSerializedJWSRS256Const)
     }
 
+
     @available(*, deprecated)
     func testSignAndSerializeRS512() {
-        self.performTestRSASign(algorithm: .RS512, compactSerializedJWS: compactSerializedJWSRS512Const)
+        self.performTestRSASign(algorithm: .RS512)
+    }
+
+    @available(*, deprecated)
+    func testSignAndVerifyRS512WithNonRequiredHeaderParameter() {
+        self.performTestRSASign(algorithm: .RS512, withKid: true)
     }
 
     func testDeserializeFromCompactSerializationRS512() {
@@ -54,13 +65,17 @@ class JWSTests: CryptoTestCase {
     // MARK: - RSA Tests
 
     @available(*, deprecated)
-    private func performTestRSASign(algorithm: SignatureAlgorithm, compactSerializedJWS: String) {
+    private func performTestRSASign(algorithm: SignatureAlgorithm, withKid: Bool? = false) {
         guard publicKeyAlice2048 != nil, privateKeyAlice2048 != nil else {
             XCTFail()
             return
         }
 
-        let header = JWSHeader(algorithm: algorithm)
+        var header = JWSHeader(algorithm: algorithm)
+        if withKid ?? false {
+            header.kid = "kid"
+        }
+
         let payload = Payload(message.data(using: .utf8)!)
         let signer = Signer(signingAlgorithm: algorithm, privateKey: privateKeyAlice2048!)!
         let jws = try! JWS(header: header, payload: payload, signer: signer)


### PR DESCRIPTION
Fixes #109 

## Description 

Add an additional argument for the `kid` parameter (defaults to nil) when initializing `JWEHeader`. So it can be called with a `kid` parameter or easily without. So this is not a breaking change.

``` swift
// With kid
JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512, keyIdentifier: "kid")

// Without kid
JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512)
```

The additional parameter gets set to the internal `parameter` dictionary, so when reading out the value of `kid` the value gets returned. 

``` swift
let header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512, keyIdentifier: "kid")
print(header.kid) // "kid"
```

## Tests

I added a test for this.

## Update Documentation

I am not quite sure how the contribution-flow should look like for editing the Wiki as I can't put the changes of the Wiki here into this PR. So, I updated the README and added the `keyIdentifier` parameter when initializing the `JWEHeader`. But, I think, an extra information in the wiki would be nice. I opened a new issue #111 with updated content for the wiki, you can then use the content from there to update the wiki. 