### PR TITLE
Mention ignored JWK parameters in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ let publicKey: SecKey = try! jwk.converted(to: SecKey.self)
 
 More details about decoding RSA public keys can be found [in the wiki](../../wiki/jwk).
 
+:warning: We currently ignore the key parameters [`"key_ops"`](https://tools.ietf.org/html/rfc7517#section-4.3) and [`"x5c"`](https://tools.ietf.org/html/rfc7517#section-4.7) when decoding. This is due to a bug in our decoding implementation. See #117 for details.
+
 ## Security
 
 JOSESwift uses the [iOS Security framework](https://developer.apple.com/documentation/security) and [Apple’s CommonCrypto](https://opensource.apple.com//source/CommonCrypto/) for cryptography.

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ let publicKey: SecKey = try! jwk.converted(to: SecKey.self)
 
 More details about decoding RSA public keys can be found [in the wiki](../../wiki/jwk).
 
-:warning: We currently ignore the key parameters [`"key_ops"`](https://tools.ietf.org/html/rfc7517#section-4.3) and [`"x5c"`](https://tools.ietf.org/html/rfc7517#section-4.7) when decoding. This is due to a bug in our decoding implementation. See #117 for details.
+:warning: We currently ignore the key parameters [`"key_ops"`](https://tools.ietf.org/html/rfc7517#section-4.3) and [`"x5c"`](https://tools.ietf.org/html/rfc7517#section-4.7) when decoding. This is due to a bug in our decoding implementation. See [#117](https://github.com/airsidemobile/JOSESwift/issues/117) for details.
 
 ## Security
 


### PR DESCRIPTION
📃 Mentions that we now ignore the `[String]` JWS parameters that we currently cannot decode (as reported in #86 and tracked to fix in #117).

Once merged, I'll add that note to the wiki as well.