### PR TITLE
Swift 4.2 Upgrade

### DIFF
--- a/JOSESwift.xcodeproj/project.pbxproj
+++ b/JOSESwift.xcodeproj/project.pbxproj
@@ -539,12 +539,13 @@
 					65A9D3D61F45CDD7004E0B61 = {
 						CreatedOnToolsVersion = 8.3.3;
 						DevelopmentTeam = 4857DE3DAC;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 					65FBFDE11F45CC7C005C7D68 = {
 						CreatedOnToolsVersion = 8.3.3;
 						DevelopmentTeam = 4857DE3DAC;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
 					C8610F5F2031A4C700859FCC = {
@@ -719,7 +720,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/Pods";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airsidemobile.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -732,7 +733,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/Pods";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airsidemobile.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -875,8 +876,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -897,8 +897,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.airsidemobile.JOSESwift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
## Description

Performs the Xcode migrator steps to compile the pod using the latest language version.

This fixes the Swift 4.2 migration hint that users of this pod are presented with.

This is just a trivial migration, since no code changes were necessary.
I looked at the features of [Swift 4.2][] to see if there is anything useful, but AFAICT there are no real benefits.

[Swift 4.2]: https://github.com/ole/whats-new-in-swift-4-2