### PR TITLE
Added A128CBC-HS256 support

### DIFF
--- a/JOSESwift/Sources/Algorithms.swift
+++ b/JOSESwift/Sources/Algorithms.swift
@@ -45,18 +45,23 @@ public enum AsymmetricKeyAlgorithm: String {
 /// - A256CBC-HS512: [AES_256_CBC_HMAC_SHA_512](https://tools.ietf.org/html/rfc7518#section-5.2.5)
 public enum SymmetricKeyAlgorithm: String {
     case A256CBCHS512 = "A256CBC-HS512"
+	case A128CBCHS256 = "A128CBC-HS256"
 
     var hmacAlgorithm: HMACAlgorithm {
         switch self {
         case .A256CBCHS512:
             return .SHA512
+		case .A128CBCHS256:
+			return .SHA256
         }
     }
 
-    var keyLength: Int {
+    public var keyLength: Int {
         switch self {
         case .A256CBCHS512:
             return 64
+		case .A128CBCHS256:
+			return 32
         }
     }
 
@@ -64,6 +69,8 @@ public enum SymmetricKeyAlgorithm: String {
         switch self {
         case .A256CBCHS512:
             return 16
+		case .A128CBCHS256:
+			return 16
         }
     }
 
@@ -71,6 +78,8 @@ public enum SymmetricKeyAlgorithm: String {
         switch self {
         case .A256CBCHS512:
             return key.count == 64
+		case .A128CBCHS256:
+			return key.count == 32
         }
     }
 
@@ -80,8 +89,13 @@ public enum SymmetricKeyAlgorithm: String {
             guard checkKeyLength(for: inputKey) else {
                 throw JWEError.keyLengthNotSatisfied
             }
+			return (inputKey.subdata(in: 0..<32), inputKey.subdata(in: 32..<64))
 
-            return (inputKey.subdata(in: 0..<32), inputKey.subdata(in: 32..<64))
+		case .A128CBCHS256:
+			guard checkKeyLength(for: inputKey) else {
+				throw JWEError.keyLengthNotSatisfied
+			}
+			return (inputKey.subdata(in: 0..<16), inputKey.subdata(in: 16..<32))
         }
     }
 
@@ -89,6 +103,8 @@ public enum SymmetricKeyAlgorithm: String {
         switch self {
         case .A256CBCHS512:
             return hmac.subdata(in: 0..<32)
+		case .A128CBCHS256:
+			return hmac.subdata(in: 0..<16)
         }
     }
 }
@@ -98,11 +114,14 @@ public enum SymmetricKeyAlgorithm: String {
 /// - SHA512
 public enum HMACAlgorithm: String {
     case SHA512 = "SHA512"
+	case SHA256 = "SHA256"
 
     var outputLength: Int {
         switch self {
         case .SHA512:
             return 64
+		case .SHA256:
+			return 32
         }
     }
 }

--- a/JOSESwift/Sources/CryptoImplementation/AES.swift
+++ b/JOSESwift/Sources/CryptoImplementation/AES.swift
@@ -35,6 +35,8 @@ fileprivate extension SymmetricKeyAlgorithm {
         switch self {
         case .A256CBCHS512:
             return CCAlgorithm(kCCAlgorithmAES128)
+		case .A128CBCHS256:
+			return CCAlgorithm(kCCAlgorithmAES128)
         }
     }
 
@@ -42,6 +44,8 @@ fileprivate extension SymmetricKeyAlgorithm {
         switch self {
         case .A256CBCHS512:
             return key.count == kCCKeySizeAES256
+		case .A128CBCHS256:
+			return key.count == kCCKeySizeAES128
         }
     }
 }
@@ -60,7 +64,7 @@ internal struct AES {
     /// - Throws: `AESError` if any error occurs during encryption.
     static func encrypt(plaintext: Data, with encryptionKey: KeyType, using algorithm: SymmetricKeyAlgorithm, and initializationVector: Data) throws -> Data {
         switch algorithm {
-        case .A256CBCHS512:
+		case .A256CBCHS512, .A128CBCHS256:
             guard algorithm.checkAESKeyLength(for: encryptionKey) else {
                 throw AESError.keyLengthNotSatisfied
             }
@@ -86,7 +90,7 @@ internal struct AES {
     /// - Throws: `AESError` if any error occurs during decryption.
     static func decrypt(cipherText: Data, with decryptionKey: Data, using algorithm: SymmetricKeyAlgorithm, and initializationVector: Data) throws -> Data {
         switch algorithm {
-        case .A256CBCHS512:
+		case .A256CBCHS512, .A128CBCHS256:
             guard algorithm.checkAESKeyLength(for: decryptionKey) else {
                 throw AESError.keyLengthNotSatisfied
             }

--- a/JOSESwift/Sources/CryptoImplementation/HMAC.swift
+++ b/JOSESwift/Sources/CryptoImplementation/HMAC.swift
@@ -29,8 +29,10 @@ fileprivate extension HMACAlgorithm {
         switch self {
         case .SHA512:
             return CCAlgorithm(kCCHmacAlgSHA512)
+		case .SHA256:
+			return CCAlgorithm(kCCHmacAlgSHA256)
         }
-    }
+	}
 }
 
 internal struct HMAC {

--- a/JOSESwift/Sources/Decrypter.swift
+++ b/JOSESwift/Sources/Decrypter.swift
@@ -79,14 +79,14 @@ public struct Decrypter {
     /// - Returns: A fully initialized `Decrypter` or `nil` if provided key is of the wrong type.
     public init?<KeyType>(keyDecryptionAlgorithm: AsymmetricKeyAlgorithm, decryptionKey key: KeyType, contentDecryptionAlgorithm: SymmetricKeyAlgorithm) {
         switch (keyDecryptionAlgorithm, contentDecryptionAlgorithm) {
-        case (.RSA1_5, .A256CBCHS512):
+		case (.RSA1_5, .A256CBCHS512), (.RSA1_5, .A128CBCHS256):
             guard type(of: key) is RSADecrypter.KeyType.Type else {
                 return nil
             }
             // swiftlint:disable:next force_cast
             self.asymmetric = RSADecrypter(algorithm: keyDecryptionAlgorithm, privateKey: (key as! RSADecrypter.KeyType))
             self.symmetric = AESDecrypter(algorithm: contentDecryptionAlgorithm)
-        case (.direct, .A256CBCHS512):
+		case (.direct, .A256CBCHS512), (.direct, .A128CBCHS256):
             guard type(of: key) is AESDecrypter.KeyType.Type else {
                 return nil
             }

--- a/JOSESwift/Sources/Encrypter.swift
+++ b/JOSESwift/Sources/Encrypter.swift
@@ -80,14 +80,14 @@ public struct Encrypter<KeyType> {
     /// - Returns: A fully initialized `Encrypter` or `nil` if provided key is of the wrong type.
     public init?(keyEncryptionAlgorithm: AsymmetricKeyAlgorithm, encryptionKey key: KeyType, contentEncyptionAlgorithm: SymmetricKeyAlgorithm) {
         switch (keyEncryptionAlgorithm, contentEncyptionAlgorithm) {
-        case (.RSA1_5, .A256CBCHS512):
+		case (.RSA1_5, .A256CBCHS512), (.RSA1_5, .A128CBCHS256):
             guard type(of: key) is RSAEncrypter.KeyType.Type else {
                 return nil
             }
             // swiftlint:disable:next force_cast
             self.asymmetric = RSAEncrypter(algorithm: keyEncryptionAlgorithm, publicKey: (key as! RSAEncrypter.KeyType))
             self.symmetric = AESEncrypter(algorithm: contentEncyptionAlgorithm)
-        case (.direct, .A256CBCHS512):
+		case (.direct, .A256CBCHS512), (.direct, .A128CBCHS256):
             guard type(of: key) is AESEncrypter.KeyType.Type else {
                 return nil
             }

--- a/JOSESwift/Sources/JOSEHeader.swift
+++ b/JOSESwift/Sources/JOSEHeader.swift
@@ -62,14 +62,14 @@ extension JOSEHeader {
 /// JWS and JWE share a common Header Parameter space that both JWS and JWE headers must support.
 /// Those header parameters may have a different meaning depending on whether they are part of a JWE or JWS.
 public protocol CommonHeaderParameterSpace {
-    var jku: URL? { get set }
-    var jwk: String? { get set }
-    var kid: String? { get set }
-    var x5u: URL? { get set }
-    var x5c: [String]? { get set }
-    var x5t: String? { get set }
-    var x5tS256: String? { get set }
-    var typ: String? { get set }
-    var cty: String? { get set }
-    var crit: [String]? { get set }
+    var jku: URL? { get }
+    var jwk: String? { get }
+    var kid: String? { get }
+    var x5u: URL? { get }
+    var x5c: [String: Any]? { get }
+    var x5t: String? { get }
+    var x5tS256: String? { get }
+    var typ: String? { get }
+    var cty: String? { get }
+    var crit: [String]? { get }
 }

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -25,17 +25,8 @@ import Foundation
 
 /// The header of a `JWE` object.
 public struct JWEHeader: JOSEHeader {
-    var headerData: Data
-    var parameters: [String: Any] {
-        didSet {
-            guard JSONSerialization.isValidJSONObject(parameters) else {
-                return
-            }
-            // Forcing the try is ok here, because it is valid JSON.
-            // swiftlint:disable:next force_try
-            headerData = try! JSONSerialization.data(withJSONObject: parameters, options: [])
-        }
-    }
+    let headerData: Data
+    let parameters: [String: Any]
 
     /// Initializes a JWE header with given parameters and their original `Data` representation.
     /// Note that this (base64-url decoded) `Data` representation has to be exactly as it was
@@ -64,11 +55,15 @@ public struct JWEHeader: JOSEHeader {
     }
 
     /// Initializes a `JWEHeader` with the specified algorithm and signing algorithm.
-    public init(algorithm: AsymmetricKeyAlgorithm, encryptionAlgorithm: SymmetricKeyAlgorithm) {
-        let parameters = [
+	public init(algorithm: AsymmetricKeyAlgorithm, encryptionAlgorithm: SymmetricKeyAlgorithm, kid: String? = nil) {
+        var parameters = [
             "alg": algorithm.rawValue,
             "enc": encryptionAlgorithm.rawValue
         ]
+		
+		if let kid = kid {
+			parameters["kid"] = kid
+		}
 
         // Forcing the try is ok here, since [String: String] can be converted to JSON.
         // swiftlint:disable:next force_try
@@ -104,111 +99,55 @@ extension JWEHeader: CommonHeaderParameterSpace {
     /// The JWK Set URL which refers to a resource for a set of JSON-encoded public keys,
     /// one of which corresponds to the key used to encrypt the JWE.
     public var jku: URL? {
-        set {
-            parameters["jku"] = newValue?.absoluteString
-        }
-        get {
-            guard let parameter = parameters["jku"] as? String else {
-                return nil
-            }
-            return URL(string: parameter)
-        }
+        return parameters["jku"] as? URL
     }
 
     /// The JSON Web key corresponding to the key used to encrypt the JWE.
     public var jwk: String? {
-        set {
-            parameters["jwk"] = newValue
-        }
-        get {
-            return parameters["jwk"] as? String
-        }
+        return parameters["jwk"] as? String
     }
 
     /// The Key ID indicates the key which was used to encrypt the JWE.
     public var kid: String? {
-        set {
-            parameters["kid"] = newValue
-        }
-        get {
-            return parameters["kid"] as? String
-        }
+        return parameters["kid"] as? String
     }
 
     /// The X.509 URL that referes to a resource for the X.509 public key certificate
     /// or certificate chain corresponding to the key used to encrypt the JWE.
     public var x5u: URL? {
-        set {
-            parameters["x5u"] = newValue?.absoluteString
-        }
-        get {
-            guard let parameter = parameters["x5u"] as? String else {
-                return nil
-            }
-            return URL(string: parameter)
-        }
+        return parameters["x5u"] as? URL
     }
 
     /// The X.509 certificate chain contains the X.509 public key certificate or
     /// certificate chain corresponding to the key used to encrypt the JWE.
-    public var x5c: [String]? {
-        set {
-            parameters["x5c"] = newValue
-        }
-        get {
-            return parameters["x5c"] as? [String]
-        }
+    public var x5c: [String: Any]? {
+        return parameters["x5c"] as? [String: Any]
     }
 
     /// The X.509 certificate SHA-1 thumbprint of the DER encoding of the X.509 certificate
     /// corresponding to the key used to encrypt the JWE.
     public var x5t: String? {
-        set {
-            parameters["x5t"] = newValue
-        }
-        get {
-            return parameters["x5t"] as? String
-        }
+        return parameters["x5t"] as? String
     }
 
     /// The X.509 certificate SHA-256 thumbprint of the DER encoding of the X.509 certificate
     /// corresponding to the key used to encrypt the JWE.
     public var x5tS256: String? {
-        set {
-            parameters["x5tS256"] = newValue
-        }
-        get {
-            return parameters["x5tS256"] as? String
-        }
+        return parameters["x5tS256"] as? String
     }
 
     /// The type to declare the media type of the JWE object.
     public var typ: String? {
-        set {
-            parameters["typ"] = newValue
-        }
-        get {
-            return parameters["typ"] as? String
-        }
+        return parameters["typ"] as? String
     }
 
     /// The content type to declare the media type of the secured content (payload).
     public var cty: String? {
-        set {
-            parameters["cty"] = newValue
-        }
-        get {
-            return parameters["cty"] as? String
-        }
+        return parameters["cty"] as? String
     }
 
     /// The critical header parameter indicates the header parameter extensions.
     public var crit: [String]? {
-        set {
-            parameters["crit"] = newValue
-        }
-        get {
-            return parameters["crit"] as? [String]
-        }
+        return parameters["crit"] as? [String]
     }
 }

--- a/JOSESwift/Sources/JWSHeader.swift
+++ b/JOSESwift/Sources/JWSHeader.swift
@@ -25,17 +25,8 @@ import Foundation
 
 /// The header of a `JWS` object.
 public struct JWSHeader: JOSEHeader {
-    var headerData: Data
-    var parameters: [String: Any] {
-        didSet {
-            guard JSONSerialization.isValidJSONObject(parameters) else {
-                return
-            }
-            // Forcing the try is ok here, because it is valid JSON.
-            // swiftlint:disable:next force_try
-            headerData = try! JSONSerialization.data(withJSONObject: parameters, options: [])
-        }
-    }
+    let headerData: Data
+    let parameters: [String: Any]
 
     /// Initializes a JWS header with given parameters and their original `Data` representation.
     /// Note that this (base64-url decoded) `Data` representation has to be exactly as it was
@@ -89,111 +80,55 @@ extension JWSHeader: CommonHeaderParameterSpace {
     /// The JWK Set URL which refers to a resource for a set of JSON-encoded public keys,
     /// one of which corresponds to the key used to sign the JWS.
     public var jku: URL? {
-        set {
-            parameters["jku"] = newValue?.absoluteString
-        }
-        get {
-            guard let parameter = parameters["jku"] as? String else {
-                return nil
-            }
-            return URL(string: parameter)
-        }
+        return parameters["jku"] as? URL
     }
 
     /// The JSON Web key corresponding to the key used to digitally sign the JWS.
     public var jwk: String? {
-        set {
-            parameters["jwk"] = newValue
-        }
-        get {
-            return parameters["jwk"] as? String
-        }
+        return parameters["jwk"] as? String
     }
 
     /// The Key ID indicates the key which was used to secure the JWS.
     public var kid: String? {
-        set {
-            parameters["kid"] = newValue
-        }
-        get {
-            return parameters["kid"] as? String
-        }
+        return parameters["kid"] as? String
     }
 
     /// The X.509 URL that referes to a resource for the X.509 public key certificate
     /// or certificate chain corresponding to the key used to sign the JWS.
     public var x5u: URL? {
-        set {
-            parameters["x5u"] = newValue?.absoluteString
-        }
-        get {
-            guard let parameter = parameters["x5u"] as? String else {
-                return nil
-            }
-            return URL(string: parameter)
-        }
+        return parameters["x5u"] as? URL
     }
 
     /// The X.509 certificate chain contains the X.509 public key certificate or
     /// certificate chain corresponding to the key used to sign the JWS.
-    public var x5c: [String]? {
-        set {
-            parameters["x5c"] = newValue
-        }
-        get {
-            return parameters["x5c"] as? [String]
-        }
+    public var x5c: [String: Any]? {
+        return parameters["x5c"] as? [String: Any]
     }
 
     /// The X.509 certificate SHA-1 thumbprint of the DER encoding of the X.509 certificate
     /// corresponding to the key used to sign the JWS.
     public var x5t: String? {
-        set {
-            parameters["x5t"] = newValue
-        }
-        get {
-            return parameters["x5t"] as? String
-        }
+        return parameters["x5t"] as? String
     }
 
     /// The X.509 certificate SHA-256 thumbprint of the DER encoding of the X.509 certificate
     /// corresponding to the key used to sign the JWS.
     public var x5tS256: String? {
-        set {
-            parameters["x5tS256"] = newValue
-        }
-        get {
-            return parameters["x5tS256"] as? String
-        }
+        return parameters["jwk"] as? String
     }
 
     /// The type to declare the media type of the JWS object.
     public var typ: String? {
-        set {
-            parameters["typ"] = newValue
-        }
-        get {
-            return parameters["typ"] as? String
-        }
+        return parameters["typ"] as? String
     }
 
     /// The content type to declare the media type of the secured content (payload).
     public var cty: String? {
-        set {
-            parameters["cty"] = newValue
-        }
-        get {
-            return parameters["cty"] as? String
-        }
+        return parameters["cty"] as? String
     }
 
     /// The critical header parameter indicates the header parameter extensions.
     public var crit: [String]? {
-        set {
-            parameters["crit"] = newValue
-        }
-        get {
-            return parameters["crit"] as? [String]
-        }
+        return parameters["crit"] as? [String]
     }
 }


### PR DESCRIPTION
I have a fork supporting A128CBCHS256 algorithm. And supporting JWK header with kid support. Thought its added in the next version of joseswift.

Since my backend using nimbus which don't supporting A256 algorithm for some reason. It only support A256GCM. But for some reason it works with A128 :)