### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,8 @@ Include references to issue- or pull-request numbers.
 Use active language and present tense.
 For convenience, feel free to track changes in the *Unreleased* section upon
 merge to master and move them to a respective version upon release.
+
+## [1.4.0] - 2018-12-04
+
+- Changes Swift version from 4.0 to 4.2 (#217)
+- Changes `CommonCrypto` import to use Swift’s new builtin `CommonCrypto` module instead of the custom `SJCommonCrypto` module (#217, #131)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+[PSPDFKit's Changelog Format](https://pspdfkit.com/blog/2018/the-challenges-of-changelogs/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Start each entry with one of the following keywords: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Start each entry with one of the following keywords: 
 
-- *API*: For highlighting breaking API changes that require people to change 
-their implementations
+- *API*: For highlighting breaking API changes that require people to change their implementations
 - *Adds*: For listing new features
 - *Fixes*: For listing bugfixes
 - *Changes*: For listing improvements other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Use active language and present tense.
 For convenience, feel free to track changes in the *Unreleased* section upon
 merge to master and move them to a respective version upon release.
 
+## Unreleased
+
+- Security: Change fastlane version to fix [#129](https://github.com/airsidemobile/JOSESwift/issues/129) ([#130](https://github.com/airsidemobile/JOSESwift/pull/130))
+- Changes travis to use builting homebrew addon ([#133](https://github.com/airsidemobile/JOSESwift/pull/133))
+- Adds support for elliptic curve algorithms for JWS and elliptic curve keys for JWK ([#88](https://github.com/airsidemobile/JOSESwift/pull/88))
+
 ## [1.4.0] - 2018-12-04
 
 - Changes Swift version from 4.0 to 4.2 ([#127](https://github.com/airsidemobile/JOSESwift/pull/127))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,5 @@ merge to master and move them to a respective version upon release.
 
 ## [1.4.0] - 2018-12-04
 
-- Changes Swift version from 4.0 to 4.2 (#217)
+- Changes Swift version from 4.0 to 4.2 ([#127](https://github.com/airsidemobile/JOSESwift/pull/127))
 - Changes `CommonCrypto` import to use Swift’s new builtin `CommonCrypto` module instead of the custom `SJCommonCrypto` module (#217, #131)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Start each entry with one of the following keywords:
 - *API*: For highlighting breaking API changes that require people to change their implementations
 - *Adds*: For listing new features
 - *Fixes*: For listing bugfixes
-- *Changes*: For listing improvements other changes
+- *Changes*: For listing improvements and other changes
 - *Deprecates*: For listing API deprecations
 - *Security*: For highlighting changes related to security vulnerabilities
 
@@ -23,7 +23,7 @@ merge to master and move them to a respective version upon release.
 ## Unreleased
 
 - Security: Change fastlane version to fix [#129](https://github.com/airsidemobile/JOSESwift/issues/129) ([#130](https://github.com/airsidemobile/JOSESwift/pull/130))
-- Changes travis to use builting homebrew addon ([#133](https://github.com/airsidemobile/JOSESwift/pull/133))
+- Changes travis to use builtin homebrew addon ([#133](https://github.com/airsidemobile/JOSESwift/pull/133))
 - Adds support for elliptic curve algorithms for JWS and elliptic curve keys for JWK ([#88](https://github.com/airsidemobile/JOSESwift/pull/88))
 
 ## [1.4.0] - 2018-12-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Start each entry with one of the following keywords: 
+
+- *API*: For highlighting breaking API changes that require people to change 
+their implementations
+- *Adds*: For listing new features
+- *Fixes*: For listing bugfixes
+- *Improves*: For listing other changes
+- *Deprecates*: For listing API deprecations
+- *Security*: For highlighting changes related to security vulnerabilities
+
+Include references to issue- or pull-request numbers.
+Use active language and present tense.
+For convenience, feel free to track changes in the *Unreleased* section upon
+merge to master and move them to a respective version upon release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,4 +23,4 @@ merge to master and move them to a respective version upon release.
 ## [1.4.0] - 2018-12-04
 
 - Changes Swift version from 4.0 to 4.2 ([#127](https://github.com/airsidemobile/JOSESwift/pull/127))
-- Changes `CommonCrypto` import to use Swift’s new builtin `CommonCrypto` module instead of the custom `SJCommonCrypto` module (#217, #131)
+- Changes `CommonCrypto` import to use Swift’s new builtin `CommonCrypto` module instead of the custom `SJCommonCrypto` module ([#127](https://github.com/airsidemobile/JOSESwift/pull/127), [#131](https://github.com/airsidemobile/JOSESwift/pull/131))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Start each entry with one of the following keywords:
 their implementations
 - *Adds*: For listing new features
 - *Fixes*: For listing bugfixes
-- *Improves*: For listing other changes
+- *Changes*: For listing improvements other changes
 - *Deprecates*: For listing API deprecations
 - *Security*: For highlighting changes related to security vulnerabilities
 


### PR DESCRIPTION
Closes #99.

For transparency. Tell me what you think. In the future, we might want to add a Danger check that ensures people add their contributions to the _unreleased_ section and then automatically move them to a release section. Currently, nothing is automated, but I'd say that's still better than no changelog at all.