### PR TITLE
Improve EC implementation

### DIFF
--- a/JOSESwift/Sources/ECKeyCodable.swift
+++ b/JOSESwift/Sources/ECKeyCodable.swift
@@ -63,7 +63,7 @@ extension ECPublicKey: Decodable {
 
         // Other common parameters are optional.
         var parameters: [String: String] = [:]
-        for key in commonParameters.allKeys {
+        for key in commonParameters.allKeys where !JWKParameter.nonStringParameters.contains(key) {
             parameters[key.rawValue] = try commonParameters.decode(String.self, forKey: key)
         }
 
@@ -123,7 +123,7 @@ extension ECPrivateKey: Decodable {
 
         // Other common parameters are optional.
         var parameters: [String: String] = [:]
-        for key in commonParameters.allKeys {
+        for key in commonParameters.allKeys where !JWKParameter.nonStringParameters.contains(key) {
             parameters[key.rawValue] = try commonParameters.decode(String.self, forKey: key)
         }
 

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -78,6 +78,12 @@ public struct JWEHeader: JOSEHeader {
         // swiftlint:disable:next force_try
         try! self.init(parameters: parameters, headerData: headerData)
     }
+
+    /// Initializes a `JWEHeader` with the specified parameters.
+    public init(parameters: [String: Any]) throws {
+        let headerData = try JSONSerialization.data(withJSONObject: parameters, options: [])
+        try self.init(parameters: parameters, headerData: headerData)
+    }
 }
 
 // Header parameters that are specific to a JWE Header.

--- a/JOSESwift/Sources/JWKSetCodable.swift
+++ b/JOSESwift/Sources/JWKSetCodable.swift
@@ -120,17 +120,19 @@ extension JWKSet: Decodable {
             } catch JWKTypeError.typeIsSymmetric {
                 maybeKey = try? keyContainer.decode(SymmetricKey.self)
             } catch {
-                throw DecodingError.dataCorruptedError(
-                        in: keyContainer,
-                        debugDescription: "Key type could not be decoded"
-                )
+                let description =
+                    """
+                    No valid RSAPrivateKey, RSAPublicKey, SymmetricKey, ECPrivateKey, or ECPublicKey
+                    JSON found to decode.
+                    """
+                throw DecodingError.dataCorruptedError(in: keyContainer, debugDescription: description)
             }
 
             guard let key = maybeKey else {
                 let description =
-                        """
-                        No RSAPrivateKey, RSAPublicKey, SymmetricKey, ECPrivateKey, or ECPublicKey found to decode.
-                        """
+                    """
+                    No RSAPrivateKey, RSAPublicKey, SymmetricKey, ECPrivateKey, or ECPublicKey found to decode.
+                    """
                 throw DecodingError.dataCorruptedError(in: keyContainer, debugDescription: description)
             }
 

--- a/JOSESwift/Sources/JWSHeader.swift
+++ b/JOSESwift/Sources/JWSHeader.swift
@@ -71,6 +71,7 @@ public struct JWSHeader: JOSEHeader {
         try! self.init(parameters: parameters)
     }
 
+    /// Initializes a `JWSHeader` with the specified parameters.
     public init(parameters: [String: Any]) throws {
         let headerData = try JSONSerialization.data(withJSONObject: parameters, options: [])
         try self.init(parameters: parameters, headerData: headerData)

--- a/Tests/JWEHeaderTests.swift
+++ b/Tests/JWEHeaderTests.swift
@@ -99,9 +99,22 @@ class JWEHeaderTests: XCTestCase {
         XCTFail()
     }
 
-    func testInitWithMissingRequiredAlgParameter() {
+    func testInitDirectlyWithMissingRequiredAlgParameter() {
         do {
             _ = try JWEHeader(parameters: ["enc": "something"], headerData: try! JSONSerialization.data(withJSONObject: ["enc": "something"], options: []))
+        } catch HeaderParsingError.requiredHeaderParameterMissing(let parameter) {
+            XCTAssertEqual(parameter, "alg")
+            return
+        } catch {
+            XCTFail()
+        }
+
+        XCTFail()
+    }
+
+    func testInitWithMissingRequiredAlgParameter() {
+        do {
+            _ = try JWEHeader(parameters: ["enc": "something"])
         } catch HeaderParsingError.requiredHeaderParameterMissing(let parameter) {
             XCTAssertEqual(parameter, "alg")
             return

--- a/Tests/JWKECDecodingTests.swift
+++ b/Tests/JWKECDecodingTests.swift
@@ -215,6 +215,29 @@ class JWKECDecodingTests: ECCryptoTestCase {
         XCTFail()
     }
 
+    func testBuildingJWKSetShouldNotFailIfCertificatesOrKeyOpsArePresent() {
+        let jwkSet = """
+        {
+            "keys": [{
+                \(Consts.innerKeyJSONKeyType),
+                \(Consts.innerKeyJSONX),
+                \(Consts.innerKeyJSONY),
+                \(Consts.innerKeyJSOND),
+                \(Consts.innerKeyJSON),
+                "x5c": ["Y2VydGlmaWNhdGUxMjM0NWRhdGEx"]
+            }, {
+                \(Consts.innerKeyJSONKeyType),
+                \(Consts.innerKeyJSONX),
+                \(Consts.innerKeyJSONY),
+                \(Consts.innerKeyJSON),
+                "key_ops": ["sign", "encrypt"]
+            }]
+        }
+        """.data(using: .utf8)!
+
+        XCTAssertNoThrow(try JWKSet(data: jwkSet))
+    }
+
     // MARK: Helper functions
 
     private func encloseJson(_ elements: [String]) -> Data {

--- a/Tests/JWSHeaderTests.swift
+++ b/Tests/JWSHeaderTests.swift
@@ -61,9 +61,22 @@ class JWSHeaderTests: XCTestCase {
         XCTAssertEqual(header.algorithm!, .RS512)
     }
 
-    func testInitWithMissingRequiredParameters() {
+    func testInitDirectlyWithMissingRequiredParameters() {
         do {
             _ = try JWSHeader(parameters: ["typ": "JWT"], headerData: try! JSONSerialization.data(withJSONObject: ["typ": "JWT"], options: []))
+        } catch HeaderParsingError.requiredHeaderParameterMissing(let parameter) {
+            XCTAssertEqual(parameter, "alg")
+            return
+        } catch {
+            XCTFail()
+        }
+
+        XCTFail()
+    }
+
+    func testInitWithMissingRequiredParameters() {
+        do {
+            _ = try JWSHeader(parameters: ["typ": "JWT"])
         } catch HeaderParsingError.requiredHeaderParameterMissing(let parameter) {
             XCTAssertEqual(parameter, "alg")
             return


### PR DESCRIPTION
Some minor improvements regarding the EC implementation in #88. Mainly the fix needed until we merge #120 to ignore non-string JWK parameters.

We can release 1.5.0 after merging this.