### PR TITLE
Prepare 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,15 @@ merge to master and move them to a respective version upon release.
 
 ## Unreleased
 
+Add your changes here.
+
+## [1.5.0] - 2019-01-23
+
 - Security: Change fastlane version to fix [#129](https://github.com/airsidemobile/JOSESwift/issues/129) ([#130](https://github.com/airsidemobile/JOSESwift/pull/130))
 - Changes travis to use builtin homebrew addon ([#133](https://github.com/airsidemobile/JOSESwift/pull/133))
 - Adds support for elliptic curve algorithms for JWS and elliptic curve keys for JWK ([#88](https://github.com/airsidemobile/JOSESwift/pull/88))
+- Changes the way elliptic curve keys are decoded to work around [#86](https://github.com/airsidemobile/JOSESwift/issues/86) until [#120](https://github.com/airsidemobile/JOSESwift/pull/120) is merged ([#137](https://github.com/airsidemobile/JOSESwift/pull/137))
+- Adds a changelog ([#136](https://github.com/airsidemobile/JOSESwift/pull/136))
 
 ## [1.4.0] - 2018-12-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,11 @@ Add your changes here.
 
 ## [1.5.0] - 2019-01-23
 
+- Adds support for elliptic curve algorithms for JWS and elliptic curve keys for JWK ([#88](https://github.com/airsidemobile/JOSESwift/pull/88))
 - Security: Change fastlane version to fix [#129](https://github.com/airsidemobile/JOSESwift/issues/129) ([#130](https://github.com/airsidemobile/JOSESwift/pull/130))
 - Changes travis to use builtin homebrew addon ([#133](https://github.com/airsidemobile/JOSESwift/pull/133))
-- Adds support for elliptic curve algorithms for JWS and elliptic curve keys for JWK ([#88](https://github.com/airsidemobile/JOSESwift/pull/88))
-- Changes the way elliptic curve keys are decoded to work around [#86](https://github.com/airsidemobile/JOSESwift/issues/86) until [#120](https://github.com/airsidemobile/JOSESwift/pull/120) is merged ([#137](https://github.com/airsidemobile/JOSESwift/pull/137))
 - Adds a changelog ([#136](https://github.com/airsidemobile/JOSESwift/pull/136))
+- Changes the way elliptic curve keys are decoded to work around [#86](https://github.com/airsidemobile/JOSESwift/issues/86) until [#120](https://github.com/airsidemobile/JOSESwift/pull/120) is merged ([#137](https://github.com/airsidemobile/JOSESwift/pull/137))
 
 ## [1.4.0] - 2018-12-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,11 @@ Add your changes here.
 
 ## [1.5.0] - 2019-01-23
 
-- Adds support for elliptic curve algorithms for JWS and elliptic curve keys for JWK ([#88](https://github.com/airsidemobile/JOSESwift/pull/88))
-- Security: Change fastlane version to fix [#129](https://github.com/airsidemobile/JOSESwift/issues/129) ([#130](https://github.com/airsidemobile/JOSESwift/pull/130))
-- Changes travis to use builtin homebrew addon ([#133](https://github.com/airsidemobile/JOSESwift/pull/133))
-- Adds a changelog ([#136](https://github.com/airsidemobile/JOSESwift/pull/136))
 - Changes the way elliptic curve keys are decoded to work around [#86](https://github.com/airsidemobile/JOSESwift/issues/86) until [#120](https://github.com/airsidemobile/JOSESwift/pull/120) is merged ([#137](https://github.com/airsidemobile/JOSESwift/pull/137))
+- Adds a changelog ([#136](https://github.com/airsidemobile/JOSESwift/pull/136))
+- Changes travis to use builtin homebrew addon ([#133](https://github.com/airsidemobile/JOSESwift/pull/133))
+- Security: Change fastlane version to fix [#129](https://github.com/airsidemobile/JOSESwift/issues/129) ([#130](https://github.com/airsidemobile/JOSESwift/pull/130))
+- Adds support for elliptic curve algorithms for JWS and elliptic curve keys for JWK ([#88](https://github.com/airsidemobile/JOSESwift/pull/88))
 
 ## [1.4.0] - 2018-12-04
 

--- a/JOSESwift.podspec
+++ b/JOSESwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "JOSESwift"
-  s.version           = "1.4.0"
+  s.version           = "1.5.0"
   s.license           = "Apache License, Version 2.0"
   s.summary           = "JOSE framework for Swift"
   s.authors           = { "Daniel Egger" => "daniel.egger@airsidemobile.com", "Carol Capek" => "carol.capek@airsidemobile.com", "Christoph Gigi Fuchs" => "christoph.fuchs@airsidemobile.com" }

--- a/JOSESwift/Sources/CryptoImplementation/DataECPrivateKey.swift
+++ b/JOSESwift/Sources/CryptoImplementation/DataECPrivateKey.swift
@@ -61,4 +61,3 @@ extension Data: ExpressibleAsECPrivateKeyComponents {
         return (curve.rawValue, xData, yData, dData)
     }
 }
-

--- a/JOSESwift/Sources/ECKeyCodable.swift
+++ b/JOSESwift/Sources/ECKeyCodable.swift
@@ -143,4 +143,3 @@ extension ECPrivateKey: Decodable {
         )
     }
 }
-

--- a/JOSESwift/Sources/Verifier.swift
+++ b/JOSESwift/Sources/Verifier.swift
@@ -54,7 +54,7 @@ public struct Verifier {
             }
             // swiftlint:disable:next force_cast
             self.verifier = RSAVerifier(algorithm: verifyingAlgorithm, publicKey: publicKey as! RSAVerifier.KeyType)
-        case .ES256,.ES384,.ES512:
+        case .ES256, .ES384, .ES512:
             guard type(of: publicKey) is ECVerifier.KeyType.Type else {
                 return nil
             }

--- a/JOSESwift/Support/Info.plist
+++ b/JOSESwift/Support/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
Mainly adds the EC functionality via #88. See changelog.

I'd say, let's release RSA-OAEP-256 (#135) as an increment (1.6.0) afterward just to be sure.