### PR TITLE
Prepare 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ merge to master and move them to a respective version upon release.
 
 Add your changes here.
 
+## [1.6.0] - 2019-01-24
+
+- Adds support for RSA-OAEP-256 ([#135](https://github.com/airsidemobile/JOSESwift/pull/135))
+
 ## [1.5.0] - 2019-01-23
 
 - Changes the way elliptic curve keys are decoded to work around [#86](https://github.com/airsidemobile/JOSESwift/issues/86) until [#120](https://github.com/airsidemobile/JOSESwift/pull/120) is merged ([#137](https://github.com/airsidemobile/JOSESwift/pull/137))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ merge to master and move them to a respective version upon release.
 
 Add your changes here.
 
-## [1.6.0] - 2019-01-24
+## [1.6.0] - 2019-01-25
 
 - Adds support for RSA-OAEP-256 ([#135](https://github.com/airsidemobile/JOSESwift/pull/135))
 

--- a/JOSESwift.podspec
+++ b/JOSESwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "JOSESwift"
-  s.version           = "1.5.0"
+  s.version           = "1.6.0"
   s.license           = "Apache License, Version 2.0"
   s.summary           = "JOSE framework for Swift"
   s.authors           = { "Daniel Egger" => "daniel.egger@airsidemobile.com", "Carol Capek" => "carol.capek@airsidemobile.com", "Christoph Gigi Fuchs" => "christoph.fuchs@airsidemobile.com" }

--- a/JOSESwift/Sources/CryptoImplementation/RSA.swift
+++ b/JOSESwift/Sources/CryptoImplementation/RSA.swift
@@ -60,22 +60,21 @@ internal extension AsymmetricKeyAlgorithm {
         }
     }
 
-    /**
-     This method returns the maximum message length allow for an Asymmetric Algorithm
-     - parameters:
-        - publicKey: SecKey the publicKey used to acquire the SecKey block size
-     - returns: Int the maximum length allowed
-     discussion:
-     - RSA1_5: For detailed information about the allowed plain text length for RSAES-PKCS1-v1_5, please refer to the RFC(https://tools.ietf.org/html/rfc3447#section-7.2)
-     - RSAOAEP256: For detailed information about the allowed plain text length for RSA-OAEP, please refer to the RFC(https://tools.ietf.org/html/rfc3447#section-7.1)
-    */
+
+    /// This method returns the maximum message length allowed for an `AsymmetricKeyAlgorithm`
+    /// - parameters:
+    ///    - `publicKey: SecKey the publicKey used to acquire the SecKey block size
+    /// - returns: Int the maximum messeage length allowed for use with the algorithm
+    /// discussion:
+    /// - RSA1_5: For detailed information about the allowed plain text length for RSAES-PKCS1-v1_5, please refer to [RFC-3447, Section 7.2](https://tools.ietf.org/html/rfc3447#section-7.2).
+    /// - RSAOAEP256: For detailed information about the allowed plain text length for RSA-OAEP, please refer to [RFC-3447, Section 7.1](https://tools.ietf.org/html/rfc3447#section-7.1).
     func maxMessageLength(for publicKey: SecKey) -> Int {
         let k = SecKeyGetBlockSize(publicKey)
         switch self {
         case .RSA1_5:
             return (k - 11)
         case .RSAOAEP256:
-            /// hash length calculation based on SHA-256 algorithm
+            // plaintext length is based on the hash length of SHA-256
             let hLen = 256 / 8
             return (k - 2 * hLen - 2)
         case .direct: return 0

--- a/JOSESwift/Sources/CryptoImplementation/RSA.swift
+++ b/JOSESwift/Sources/CryptoImplementation/RSA.swift
@@ -62,18 +62,20 @@ internal extension AsymmetricKeyAlgorithm {
 
 
     /// This method returns the maximum message length allowed for an `AsymmetricKeyAlgorithm`.
-    /// - Parameter publicKey: the publicKey used with the algorithm
-    /// - Returns: The maximum messeage length allowed for use with the algorithm
+    /// - Parameter publicKey: The publicKey used with the algorithm.
+    /// - Returns: The maximum message length allowed for use with the algorithm.
     ///
-    /// - RSA1_5: For detailed information about the allowed plain text length for RSAES-PKCS1-v1_5, please refer to [RFC-3447, Section 7.2](https://tools.ietf.org/html/rfc3447#section-7.2).
-    /// - RSAOAEP256: For detailed information about the allowed plain text length for RSA-OAEP, please refer to [RFC-3447, Section 7.1](https://tools.ietf.org/html/rfc3447#section-7.1).
+    /// - RSA1_5: For detailed information about the allowed plain text length for RSAES-PKCS1-v1_5,
+    /// please refer to [RFC-3447, Section 7.2](https://tools.ietf.org/html/rfc3447#section-7.2).
+    /// - RSAOAEP256: For detailed information about the allowed plain text length for RSA-OAEP,
+    /// please refer to [RFC-3447, Section 7.1](https://tools.ietf.org/html/rfc3447#section-7.1).
     func maxMessageLength(for publicKey: SecKey) -> Int {
         let k = SecKeyGetBlockSize(publicKey)
         switch self {
         case .RSA1_5:
             return (k - 11)
         case .RSAOAEP256:
-            // maximum plaintext length is based on the hash length of SHA-256
+            // The maximum plaintext length is based on the hash length of SHA-256.
             let hLen = 256 / 8
             return (k - 2 * hLen - 2)
         case .direct: return 0

--- a/JOSESwift/Sources/CryptoImplementation/RSA.swift
+++ b/JOSESwift/Sources/CryptoImplementation/RSA.swift
@@ -61,11 +61,10 @@ internal extension AsymmetricKeyAlgorithm {
     }
 
 
-    /// This method returns the maximum message length allowed for an `AsymmetricKeyAlgorithm`
-    /// - parameters:
-    ///    - `publicKey: SecKey the publicKey used to acquire the SecKey block size
-    /// - returns: Int the maximum messeage length allowed for use with the algorithm
-    /// discussion:
+    /// This method returns the maximum message length allowed for an `AsymmetricKeyAlgorithm`.
+    /// - Parameter publicKey: the publicKey used with the algorithm
+    /// - Returns: The maximum messeage length allowed for use with the algorithm
+    ///
     /// - RSA1_5: For detailed information about the allowed plain text length for RSAES-PKCS1-v1_5, please refer to [RFC-3447, Section 7.2](https://tools.ietf.org/html/rfc3447#section-7.2).
     /// - RSAOAEP256: For detailed information about the allowed plain text length for RSA-OAEP, please refer to [RFC-3447, Section 7.1](https://tools.ietf.org/html/rfc3447#section-7.1).
     func maxMessageLength(for publicKey: SecKey) -> Int {

--- a/JOSESwift/Sources/CryptoImplementation/RSA.swift
+++ b/JOSESwift/Sources/CryptoImplementation/RSA.swift
@@ -73,7 +73,7 @@ internal extension AsymmetricKeyAlgorithm {
         case .RSA1_5:
             return (k - 11)
         case .RSAOAEP256:
-            // plaintext length is based on the hash length of SHA-256
+            // maximum plaintext length is based on the hash length of SHA-256
             let hLen = 256 / 8
             return (k - 2 * hLen - 2)
         case .direct: return 0

--- a/JOSESwift/Support/Info.plist
+++ b/JOSESwift/Support/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
Includes RSA-OAEP-256 support (#135) by @stulevine.