### PR TITLE
Restyle features section in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ merge to master and move them to a respective version upon release.
 
 ## Unreleased
 
+- Restyle features section in readme ([#143](https://github.com/airsidemobile/JOSESwift/pull/143))
+
 Add your changes here.
 
 ## [1.6.0] - 2019-01-25

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ JOSESwift currently supports the following cryptographic algorithms:
 		<th colspan="2"><a href="https://tools.ietf.org/html/rfc7518#section-6">Keys</a></th>
 	</tr>
 	<tr><td><code>HS256</code></td><td></td>                   <td><code>RSA1_5</code></td><td>:white_check_mark:</td>       <td><code>A128CBC-HS256</code></td><td></td>                   <td><code>RSA</code></td><td>:white_check_mark:</td></tr>
-	<tr><td><code>HS384</code></td><td></td>                   <td><code>RSA-OAEP</code></td><td></td>                       <td><code>A128CBC-HS384</code></td><td></td>                   <td><code>EC</code></td><td>:white_check_mark:</td></tr>
+	<tr><td><code>HS384</code></td><td></td>                   <td><code>RSA-OAEP</code></td><td>:white_check_mark:</td>     <td><code>A128CBC-HS384</code></td><td></td>                   <td><code>EC</code></td><td>:white_check_mark:</td></tr>
 	<tr><td><code>HS512</code></td><td></td>                   <td><code>RSA-OAEP-256</code></td><td>:white_check_mark:</td> <td><code>A128CBC-HS512</code></td><td>:white_check_mark:</td> <td><code>oct</code></td><td>:white_check_mark:</td></tr>
 	<tr><td><code>RS256</code></td><td>:white_check_mark:</td> <td><code>A128KW</code></td><td></td>                         <td><code>A128GCM</code></td><td></td>                         <th rowspan="14"></th><th rowspan="14"></th></tr>
 	<tr><td><code>RS384</code></td><td></td>                   <td><code>A192KW</code></td><td></td>                         <td><code>A192GCM</code></td><td></td>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <br>
 
 **JOSESwift** is a modular and extensible framework for the [JOSE](https://datatracker.ietf.org/wg/jose/about/) standards [**JWS**](https://tools.ietf.org/html/rfc7515), [**JWE**](https://tools.ietf.org/html/rfc7516), and [**JWK**](https://tools.ietf.org/html/rfc7517) written in Swift. 
-It is designed with usage on iOS and pure Swift environments in mind.
+It is designed for usage on iOS but could be extended to be used in pure Swift environments.
 
 [![Build Status](https://travis-ci.org/airsidemobile/JOSESwift.svg?branch=master)](https://travis-ci.org/airsidemobile/JOSESwift)
 
@@ -17,7 +17,6 @@ As of now, usage is limited to iOS. See [Security](#security) for details.
 - [Installation](#installation)
 	- [CocoaPods](#cocoapods)
 	- [Carthage](#carthage)
-	- [Swift Package Manager](#swift-package-manager)
 - [Usage](#usage)
 	- [JWS: Digital Signatures](#jws-digital-signatures)
 	- [JWE: Encryption and Decryption](#jwe-encryption-and-decryption)
@@ -31,51 +30,55 @@ As of now, usage is limited to iOS. See [Security](#security) for details.
 
 ## Features
 
+- **JWS**: Digitally signing and verifying arbitrary data using the JWS standard.
+- **JWE**: Encrypting and decrypting arbitrary data using the JWE standard.
+- **JWK**: Encoding and decoding cryptographic keys.
+
+JOSESwift currently supports the following cryptographic algorithms:
+
+<table>
+	<tr>
+		<th colspan="2">🔏 JWS</th>
+		<th rowspan="19"></th>
+		<th colspan="4">🔐 JWE</th>
+		<th rowspan="19"></th>
+		<th colspan="2">🔑 JWK</th>
+	</tr>
+	<tr>
+		<th colspan="2"><a href="https://tools.ietf.org/html/rfc7518#section-3">Digital Signatures and MACs</a></th>
+		<th colspan="2"><a href="https://tools.ietf.org/html/rfc7518#section-4">Key Management</a></th>
+		<th colspan="2"><a href="https://tools.ietf.org/html/rfc7518#section-5">Content Encryption</a></th>
+		<th colspan="2"><a href="https://tools.ietf.org/html/rfc7518#section-6">Keys</a></th>
+	</tr>
+	<tr><td><code>HS256</code></td><td></td>                   <td><code>RSA1_5</code></td><td>:white_check_mark:</td>       <td><code>A128CBC-HS256</code></td><td></td>                   <td><code>RSA</code></td><td>:white_check_mark:</td></tr>
+	<tr><td><code>HS384</code></td><td></td>                   <td><code>RSA-OAEP</code></td><td></td>                       <td><code>A128CBC-HS384</code></td><td></td>                   <td><code>EC</code></td><td>:white_check_mark:</td></tr>
+	<tr><td><code>HS512</code></td><td></td>                   <td><code>RSA-OAEP-256</code></td><td>:white_check_mark:</td> <td><code>A128CBC-HS512</code></td><td>:white_check_mark:</td> <td><code>oct</code></td><td>:white_check_mark:</td></tr>
+	<tr><td><code>RS256</code></td><td>:white_check_mark:</td> <td><code>A128KW</code></td><td></td>                         <td><code>A128GCM</code></td><td></td>                         <th rowspan="14"></th><th rowspan="14"></th></tr>
+	<tr><td><code>RS384</code></td><td></td>                   <td><code>A192KW</code></td><td></td>                         <td><code>A192GCM</code></td><td></td>
+	<tr><td><code>RS512</code></td><td>:white_check_mark:</td> <td><code>A256KW</code></td><td></td>                         <td><code>A256GCM</code></td><td></td>
+	<tr><td><code>ES256</code></td><td>:white_check_mark:</td> <td><code>dir</code></td><td>:white_check_mark:</td>          <th rowspan="11"></th><th rowspan="11"></th></tr>
+	<tr><td><code>ES384</code></td><td>:white_check_mark:</td> <td><code>ECDH-ES</code></td><td></td></tr>
+	<tr><td><code>ES512</code></td><td>:white_check_mark:</td> <td><code>ECDH-ES+A128KW</code></td><td></td></tr>
+	<tr><td><code>PS256</code></td><td></td>                   <td><code>ECDH-ES+A192KW</code></td><td></td></tr>
+	<tr><td><code>PS384</code></td><td></td>                   <td><code>ECDH-ES+A256KW</code></td><td></td></tr>
+	<tr><td><code>PS512</code></td><td></td>                   <td><code>A128GCMKW</code></td><td></td></tr>
+	<tr><th rowspan="5"></th><th rowspan="5"></th>             <td><code>A192GCMKW</code></td><td></td></tr>
+	<tr>                                                       <td><code>A256GCMKW</code></td><td></td></tr>
+	<tr>                                                       <td><code>PBES2-HS256+A128KW</code></td><td></td></tr>
+	<tr>                                                       <td><code>PBES2-HS384+A192KW</code></td><td></td></tr>
+	<tr>                                                       <td><code>PBES2-HS512+A256KW</code></td><td></td></tr>
+</table>
+
+For interchangeability JOSESwift currently supports the following serializations and formats:
+
+<table>
+	<tr><th>JWS</th><th>JWE</th><th>JWK</th></tr>
+	<tr><th>Serialization</th><th>Serialization</th><th>Format</th>
+	<tr></td><td rowspan="2">Compact</td><td rowspan="2">Compact</td><td>JSON</td></tr>
+	<tr><td>JWK Set</td></tr>
+</table>
+
 If you are missing a specific feature, algorithm, or serialization, feel free to [submit a pull request](#contributing).
-
-### General
-
-*Supported serializations:*
-
-| Compact Serialization | JSON Serialization |
-| :-------------------: | :----------------: |
-| :white_check_mark:    |                    |
-
-### JWS :pencil:
-
-Digitally signing and verifying arbitrary data using the JWS standard.
-
-*Supported algorithms:*
-
-| HS256 | HS384 | HS512 | RS256 | RS384 | RS512 | ES256 | ES384 | ES512 | PS256  | PS384 | PS512 |
-| :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: |
-| | | | :white_check_mark: | | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | | | |
-
-### JWE :lock:
-
-Encrypting and decrypting arbitrary data using the JWE standard.
-
-*Supported key encryption algorithms:*
-
-| RSA1_5 | RSA-OAEP | RSA-OAEP-256 | A128KW | A192KW | A256KW | dir | ECDH-ES | ECDH-ES+A128KW | ECDH-ES+A192KW | ECDH-ES+A256KW | A128GCMKW | A192GCMKW | A256GCMKW | PBES2-HS256+A128KW | PBES2-HS384+A192KW | PBES2-HS512+A256KW |
-| :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | 
-| :white_check_mark: | |:white_check_mark:| | | | :white_check_mark: | | | | | | | | | | |
-
-*Supported content encryption algorithms:*
-
-| A128CBC-HS256 | A192CBC-HS384 | A256CBC-HS512 | A128GCM | A192GCM | A256GCM |
-| :--: | :--: | :--: | :--: | :--: | :--: |
-| | | :white_check_mark: | | | |
-
-### JWK :key:
-
-Encoding and decoding RSA public key data in PKCS#1 format as well as iOS `SecKey`s.
-
-*Supported key types:*
-
-| EC | RSA | oct |
-| :--: | :--: | :--: |
-| :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ If you are missing a specific feature, algorithm, or serialization, feel free to
 
 ### Serializations
 
-For interchangeability JOSESwift, supports _Compact Serialization_ [for JWS](https://tools.ietf.org/html/rfc7515#section-3.1) and [for JWE](https://tools.ietf.org/html/rfc7516#section-3.1).
+For interchangeability JOSESwift currently supports compact serialization [for JWS](https://tools.ietf.org/html/rfc7515#section-3.1) and [for JWE](https://tools.ietf.org/html/rfc7516#section-3.1).
+
+| Compact Serialization | JSON Serialization |		
+| :-------------------: | :----------------: |		
+| :white_check_mark:    |                    |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ If you are missing a specific feature, algorithm, or serialization, feel free to
 
 <table>
 	<tr>
-		<th colspan="2">🔏 JWS</th>
+		<th colspan="2">:lock_with_ink_pen: JWS</th>
 		<th rowspan="19"></th>
-		<th colspan="4">🔐 JWE</th>
+		<th colspan="4">:closed_lock_with_key: JWE</th>
 		<th rowspan="19"></th>
-		<th colspan="2">🔑 JWK</th>
+		<th colspan="2">:key: JWK</th>
 	</tr>
 	<tr>
 		<th colspan="2"><a href="https://tools.ietf.org/html/rfc7518#section-3">Digital Signatures and MACs</a></th>

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ As of now, usage is limited to iOS. See [Security](#security) for details.
 - **JWE**: Encrypting and decrypting arbitrary data using the JWE standard.
 - **JWK**: Encoding and decoding cryptographic keys.
 
-JOSESwift currently supports the following cryptographic algorithms:
+If you are missing a specific feature, algorithm, or serialization, feel free to [submit a pull request](#contributing).
+
+### Cryptographic Algorithms
 
 <table>
 	<tr>
@@ -69,16 +71,9 @@ JOSESwift currently supports the following cryptographic algorithms:
 	<tr>                                                       <td><code>PBES2-HS512+A256KW</code></td><td></td></tr>
 </table>
 
-For interchangeability JOSESwift currently supports the following serializations and formats:
+### Serializations
 
-<table>
-	<tr><th>JWS</th><th>JWE</th><th>JWK</th></tr>
-	<tr><th>Serialization</th><th>Serialization</th><th>Format</th>
-	<tr></td><td rowspan="2">Compact</td><td rowspan="2">Compact</td><td>JSON</td></tr>
-	<tr><td>JWK Set</td></tr>
-</table>
-
-If you are missing a specific feature, algorithm, or serialization, feel free to [submit a pull request](#contributing).
+For interchangeability JOSESwift, supports _Compact Serialization_ [for JWS](https://tools.ietf.org/html/rfc7515#section-3.1) and [for JWE](https://tools.ietf.org/html/rfc7516#section-3.1).
 
 ## Installation
 


### PR DESCRIPTION
With a growing set of algorithms, this should make the feature section much more readable as you don't have to scroll anymore to view all algorithms. 👀 

It's probably best to view [the rendered version of the readme](https://github.com/airsidemobile/JOSESwift/blob/feature/restlye-readme/README.md).

Let me know what you think. 💭 

---

📸 **Before**

![screen shot 2019-02-12 at 16 09 31](https://user-images.githubusercontent.com/17877496/52645210-99d5fa00-2ee0-11e9-907f-cb242a2f04cb.png)

---

📸 **After**

![screen shot 2019-02-12 at 16 06 38](https://user-images.githubusercontent.com/17877496/52645238-a65a5280-2ee0-11e9-8072-b784e2a8a8fa.png)
