### PR TITLE
Add Swiftlint build phase and fix most linting errors

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,17 +13,8 @@ disabled_rules:
   - function_body_length
   - type_body_length
   - file_length
-identifier_name:
-  validates_start_with_lowercase: false
-  excluded:
-    - to
-    - a
-    - b
-    - d
-    - k
-    - n
-    - s
-    - x
-    - y
+  - type_name
+  - identifier_name
+
 line_length:
   ignores_comments: true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,3 +4,21 @@ custom_rules:
     regex: '(\/\*\*)'
     message: "Use `///` instead of `/** ... */` for documentation comments."
     severity: warning
+
+disabled_rules:
+  - force_try
+  - force_cast
+identifier_name:
+  validates_start_with_lowercase: false
+  excluded:
+    - to
+    - a
+    - b
+    - d
+    - k
+    - n
+    - s
+    - x
+    - y
+line_length:
+  ignores_comments: true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -15,6 +15,7 @@ disabled_rules:
   - file_length
   - type_name
   - identifier_name
+  - todo
 
 line_length:
   ignores_comments: true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,11 @@ custom_rules:
 disabled_rules:
   - force_try
   - force_cast
+  - xctfail_message
+  - line_length
+  - function_body_length
+  - type_body_length
+  - file_length
 identifier_name:
   validates_start_with_lowercase: false
   excluded:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ so they can be moved to a respective version upon release.
 
 Add your changes here.
 
+- Enables SwiftLint and fixes many violations ([#98](https://github.com/airsidemobile/JOSESwift/issues/98) via [@xavierLowmiller](https://github.com/xavierLowmiller))
+
 ## [1.8.0] - 2019-03-18
 
 - Adds A128CBCHS256 support ([#147](https://github.com/airsidemobile/JOSESwift/pull/147)) via [@ramunasjurgilas](https://github.com/ramunasjurgilas)

--- a/JOSESwift.xcodeproj/project.pbxproj
+++ b/JOSESwift.xcodeproj/project.pbxproj
@@ -546,6 +546,7 @@
 				65FBFDDE1F45CC7C005C7D68 /* Frameworks */,
 				65FBFDDF1F45CC7C005C7D68 /* Headers */,
 				65FBFDE01F45CC7C005C7D68 /* Resources */,
+				4E06574B223CC78D00D7A199 /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -615,6 +616,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		4E06574B223CC78D00D7A199 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint autocorrect\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		65A9D3D31F45CDD7004E0B61 /* Sources */ = {

--- a/JOSESwift.xcodeproj/project.pbxproj
+++ b/JOSESwift.xcodeproj/project.pbxproj
@@ -634,7 +634,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint autocorrect\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint or run `brew bundle`\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/JOSESwift/Sources/ASN1DERParsing.swift
+++ b/JOSESwift/Sources/ASN1DERParsing.swift
@@ -47,6 +47,12 @@ internal enum ASN1Type {
     }
 }
 
+internal struct TLVTriplet {
+    let tag: UInt8
+    let length: [UInt8]
+    let value: [UInt8]
+}
+
 // MARK: Array Extension for Parsing
 // Inspired by: https://github.com/henrinormak/Heimdall/blob/master/Heimdall/Heimdall.swift
 
@@ -99,7 +105,7 @@ internal extension Array where Element == UInt8 {
     /// [here](https://msdn.microsoft.com/en-us/library/windows/desktop/bb540801(v=vs.85).aspx).
     ///
     /// - Returns: A triplet containing the ASN.1 type's tag, length, and value field.
-    func nextTLVTriplet() throws -> (tag: UInt8, length: [UInt8], value: [UInt8]) {
+    func nextTLVTriplet() throws -> TLVTriplet {
         var pointer = 0
 
         // DER encoding of an ASN.1 type: [ TAG | LENGTH | VALUE ].
@@ -117,7 +123,7 @@ internal extension Array where Element == UInt8 {
 
         let valueField = try readValueField(ofLength: valueFieldLength, from: self, pointer: &pointer)
 
-        return (tag: tag, length: lengthField, value: valueField)
+        return TLVTriplet(tag: tag, length: lengthField, value: valueField)
     }
 
 }

--- a/JOSESwift/Sources/Algorithms.swift
+++ b/JOSESwift/Sources/Algorithms.swift
@@ -29,11 +29,11 @@ import Foundation
 /// - RS512: [RSASSA-PKCS1-v1_5 using SHA-512](https://tools.ietf.org/html/rfc7518#section-3.3)
 /// - ES512: [ECDSA P-521 using SHA-512](https://tools.ietf.org/html/rfc7518#section-3.4)
 public enum SignatureAlgorithm: String {
-    case RS256 = "RS256"
-    case RS512 = "RS512"
-    case ES256 = "ES256"
-    case ES384 = "ES384"
-    case ES512 = "ES512"
+    case RS256
+    case RS512
+    case ES256
+    case ES384
+    case ES512
 }
 
 /// An algorithm for asymmetric encryption and decryption.
@@ -126,8 +126,8 @@ public enum SymmetricKeyAlgorithm: String {
 /// - SHA512
 /// - SHA256
 public enum HMACAlgorithm: String {
-    case SHA512 = "SHA512"
-    case SHA256 = "SHA256"
+    case SHA512
+    case SHA256
 
     var outputLength: Int {
         switch self {

--- a/JOSESwift/Sources/Algorithms.swift
+++ b/JOSESwift/Sources/Algorithms.swift
@@ -43,6 +43,7 @@ public enum SignatureAlgorithm: String {
 /// - RSAOAEP256: [RSAES OAEP using SHA-256 and MGF1 with SHA-256](https://tools.ietf.org/html/rfc7518#section-4.3)
 /// - direct: [Direct Encryption with a Shared Symmetric Key](https://tools.ietf.org/html/rfc7518#section-4.5)
 public enum AsymmetricKeyAlgorithm: String, CaseIterable {
+    // swiftlint:disable:next identifier_name
     case RSA1_5 = "RSA1_5"
     case RSAOAEP = "RSA-OAEP"
     case RSAOAEP256 = "RSA-OAEP-256"

--- a/JOSESwift/Sources/CompressionImplementation/DeflateWrapper.swift
+++ b/JOSESwift/Sources/CompressionImplementation/DeflateWrapper.swift
@@ -20,13 +20,13 @@ struct DeflateCompressor: CompressorProtocol {
     /// - note: Fixed at compression level 5 (best trade off between speed and time)
     public func compress(data: Data) throws -> Data {
         let config = (operation: COMPRESSION_STREAM_ENCODE, algorithm: COMPRESSION_ZLIB)
-        let optionalData = data.withUnsafeBytes { (sourcePtr: UnsafePointer<UInt8>) -> Data? in
-            return perform(config, source: sourcePtr, sourceSize: data.count)
+        if let data = data.withUnsafeBytes({ sourcePtr in
+            perform(config, source: sourcePtr, sourceSize: data.count)
+        }) {
+            return data
+        } else {
+            throw JOSESwiftError.compressionFailed
         }
-        if let _data = optionalData {
-            return _data
-        }
-        throw JOSESwiftError.compressionFailed
     }
 
     /// Decompresses the data using the zlib deflate algorithm. Self is expected to be a raw deflate
@@ -34,13 +34,13 @@ struct DeflateCompressor: CompressorProtocol {
     /// - returns: uncompressed data
     public func decompress(data: Data) throws -> Data {
         let config = (operation: COMPRESSION_STREAM_DECODE, algorithm: COMPRESSION_ZLIB)
-        let optionalData = data.withUnsafeBytes { (sourcePtr: UnsafePointer<UInt8>) -> Data? in
-            return perform(config, source: sourcePtr, sourceSize: data.count)
+        if let data = data.withUnsafeBytes({ sourcePtr in
+            perform(config, source: sourcePtr, sourceSize: data.count)
+        }) {
+            return data
+        } else {
+            throw JOSESwiftError.decompressionFailed
         }
-        if let _data = optionalData {
-            return _data
-        }
-        throw JOSESwiftError.decompressionFailed
     }
 }
 

--- a/JOSESwift/Sources/CryptoImplementation/AES.swift
+++ b/JOSESwift/Sources/CryptoImplementation/AES.swift
@@ -115,6 +115,7 @@ internal struct AES {
         }
     }
 
+    // swiftlint:disable:next function_parameter_count
     static func aes(operation: CCOperation, data: Data, key: Data, algorithm: CCAlgorithm, initializationVector: Data, padding: CCOptions) -> (data: Data, status: UInt32) {
         let dataLength = data.count
 

--- a/JOSESwift/Sources/CryptoImplementation/AES.swift
+++ b/JOSESwift/Sources/CryptoImplementation/AES.swift
@@ -71,7 +71,11 @@ internal struct AES {
                 throw AESError.keyLengthNotSatisfied
             }
 
-            let encrypted = aes(operation: CCOperation(kCCEncrypt), data: plaintext, key: encryptionKey, algorithm: algorithm.ccAlgorithm, initializationVector: initializationVector, padding: CCOptions(kCCOptionPKCS7Padding))
+            let encrypted = aes(operation: CCOperation(kCCEncrypt),
+                                data: plaintext, key: encryptionKey,
+                                algorithm: algorithm.ccAlgorithm,
+                                initializationVector: initializationVector,
+                                padding: CCOptions(kCCOptionPKCS7Padding))
 
             guard encrypted.status == UInt32(kCCSuccess) else {
                 throw AESError.encryptingFailed(description: "Encryption failed with status: \(encrypted.status).")
@@ -97,7 +101,11 @@ internal struct AES {
                 throw AESError.keyLengthNotSatisfied
             }
 
-            let decrypted = aes(operation: CCOperation(kCCDecrypt), data: cipherText, key: decryptionKey, algorithm: algorithm.ccAlgorithm, initializationVector: initializationVector, padding: CCOptions(kCCOptionPKCS7Padding))
+            let decrypted = aes(operation: CCOperation(kCCDecrypt),
+                                data: cipherText, key: decryptionKey,
+                                algorithm: algorithm.ccAlgorithm,
+                                initializationVector: initializationVector,
+                                padding: CCOptions(kCCOptionPKCS7Padding))
 
             guard decrypted.status == UInt32(kCCSuccess) else {
                 throw AESError.decryptingFailed(description: "Decryption failed with CryptoStatus: \(decrypted.status).")

--- a/JOSESwift/Sources/CryptoImplementation/EC.swift
+++ b/JOSESwift/Sources/CryptoImplementation/EC.swift
@@ -96,10 +96,10 @@ public enum ECCurveType: String, Codable {
 
 fileprivate extension SignatureAlgorithm {
     typealias DigestFunction = (
-            Optional<UnsafeRawPointer>,
+            UnsafeRawPointer?,
             UInt32,
-            Optional<UnsafeMutablePointer<UInt8>>
-    ) -> Optional<UnsafeMutablePointer<UInt8>>
+            UnsafeMutablePointer<UInt8>?
+    ) -> UnsafeMutablePointer<UInt8>?
 
     func createDigest(input: Data) throws -> [UInt8] {
         guard

--- a/JOSESwift/Sources/DataExtensions.swift
+++ b/JOSESwift/Sources/DataExtensions.swift
@@ -35,10 +35,10 @@ extension Data {
 
         let mod = s.count % 4
         switch mod {
-            case 0: break
-            case 2: s.append("==")
-            case 3: s.append("=")
-            default: return nil
+        case 0: break
+        case 2: s.append("==")
+        case 3: s.append("=")
+        default: return nil
         }
 
         self.init(base64Encoded: s)

--- a/JOSESwift/Sources/DataExtensions.swift
+++ b/JOSESwift/Sources/DataExtensions.swift
@@ -86,15 +86,15 @@ extension Data {
         var dataLengthBytes = [UInt8](repeatElement(0x00, count: 8))
 
         var dataIndex = dataLengthBytes.count-1
-        for i in stride(from: 0, to: dataLengthInHex.count, by: 2) {
+        for index in stride(from: 0, to: dataLengthInHex.count, by: 2) {
             var offset = 2
             var hexStringChunk = ""
 
-            if dataLengthInHex.count-i == 1 {
+            if dataLengthInHex.count-index == 1 {
                 offset = 1
             }
 
-            let endIndex = dataLengthInHex.index(dataLengthInHex.endIndex, offsetBy: -i)
+            let endIndex = dataLengthInHex.index(dataLengthInHex.endIndex, offsetBy: -index)
             let startIndex = dataLengthInHex.index(endIndex, offsetBy: -offset)
             let range = Range(uncheckedBounds: (lower: startIndex, upper: endIndex))
             hexStringChunk = String(dataLengthInHex[range])

--- a/JOSESwift/Sources/Decrypter.swift
+++ b/JOSESwift/Sources/Decrypter.swift
@@ -122,7 +122,7 @@ public struct Decrypter {
 
         var cek: Data
 
-        if (alg == .direct) {
+        if alg == .direct {
             guard context.encryptedKey == Data() else {
                 throw JOSESwiftError.decryptingFailed(
                     description: "Direct encryption does not expect an encrypted key."

--- a/JOSESwift/Sources/JWKSet.swift
+++ b/JOSESwift/Sources/JWKSet.swift
@@ -84,8 +84,8 @@ extension JWKSet: Collection {
         return keys[index]
     }
 
-    public func index(after i: Index) -> Index {
-        return self.keys.index(after: i)
+    public func index(after index: Index) -> Index {
+        return self.keys.index(after: index)
     }
 
     public func makeIterator() -> IndexingIterator<ArrayType> {

--- a/Tests/AESDecrypterTests.swift
+++ b/Tests/AESDecrypterTests.swift
@@ -59,12 +59,37 @@ class AESDecrypterTests: RSACryptoTestCase {
 
     /// Tests the `AES` decryption implementation for AES_256_CBC_HMAC_SHA_512 with the test data provided in the [RFC-7518](https://tools.ietf.org/html/rfc7518#appendix-B.3).
     func testDecryptingA256CBCHS512() {
-        let keyData = "00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f".hexadecimalToData()
-        let additionalAuthenticatedData = "54 68 65 20 73 65 63 6f 6e 64 20 70 72 69 6e 63 69 70 6c 65 20 6f 66 20 41 75 67 75 73 74 65 20 4b 65 72 63 6b 68 6f 66 66 73".hexadecimalToData()
+        let keyData = """
+        00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 \
+        17 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d \
+        2e 2f 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f
+        """.hexadecimalToData()
+        let additionalAuthenticatedData = """
+        54 68 65 20 73 65 63 6f 6e 64 20 70 72 69 6e 63 69 70 6c 65 20 6f 66 \
+        20 41 75 67 75 73 74 65 20 4b 65 72 63 6b 68 6f 66 66 73
+        """.hexadecimalToData()
         let iv = "1a f3 8c 2d c2 b9 6f fd d8 66 94 09 23 41 bc 04".hexadecimalToData()!
-        let ciphertext = "4a ff aa ad b7 8c 31 c5 da 4b 1b 59 0d 10 ff bd 3d d8 d5 d3 02 42 35 26 91 2d a0 37 ec bc c7 bd 82 2c 30 1d d6 7c 37 3b cc b5 84 ad 3e 92 79 c2 e6 d1 2a 13 74 b7 7f 07 75 53 df 82 94 10 44 6b 36 eb d9 70 66 29 6a e6 42 7e a7 5c 2e 08 46 a1 1a 09 cc f5 37 0d c8 0b fe cb ad 28 c7 3f 09 b3 a3 b7 5e 66 2a 25 94 41 0a e4 96 b2 e2 e6 60 9e 31 e6 e0 2c c8 37 f0 53 d2 1f 37 ff 4f 51 95 0b be 26 38 d0 9d d7 a4 93 09 30 80 6d 07 03 b1 f6".hexadecimalToData()
-        let authenticationTag = "4d d3 b4 c0 88 a7 f4 5c 21 68 39 64 5b 20 12 bf 2e 62 69 a8 c5 6a 81 6d bc 1b 26 77 61 95 5b c5".hexadecimalToData()
-        let testPlaintext = "41 20 63 69 70 68 65 72 20 73 79 73 74 65 6d 20 6d 75 73 74 20 6e 6f 74 20 62 65 20 72 65 71 75 69 72 65 64 20 74 6f 20 62 65 20 73 65 63 72 65 74 2c 20 61 6e 64 20 69 74 20 6d 75 73 74 20 62 65 20 61 62 6c 65 20 74 6f 20 66 61 6c 6c 20 69 6e 74 6f 20 74 68 65 20 68 61 6e 64 73 20 6f 66 20 74 68 65 20 65 6e 65 6d 79 20 77 69 74 68 6f 75 74 20 69 6e 63 6f 6e 76 65 6e 69 65 6e 63 65".hexadecimalToData()
+        let ciphertext = """
+        4a ff aa ad b7 8c 31 c5 da 4b 1b 59 0d 10 ff bd 3d d8 d5 d3 02 42 35 \
+        26 91 2d a0 37 ec bc c7 bd 82 2c 30 1d d6 7c 37 3b cc b5 84 ad 3e 92 \
+        79 c2 e6 d1 2a 13 74 b7 7f 07 75 53 df 82 94 10 44 6b 36 eb d9 70 66 \
+        29 6a e6 42 7e a7 5c 2e 08 46 a1 1a 09 cc f5 37 0d c8 0b fe cb ad 28 \
+        c7 3f 09 b3 a3 b7 5e 66 2a 25 94 41 0a e4 96 b2 e2 e6 60 9e 31 e6 e0 \
+        2c c8 37 f0 53 d2 1f 37 ff 4f 51 95 0b be 26 38 d0 9d d7 a4 93 09 30 \
+        80 6d 07 03 b1 f6
+        """.hexadecimalToData()
+        let authenticationTag = """
+        4d d3 b4 c0 88 a7 f4 5c 21 68 39 64 5b 20 12 bf 2e 62 69 a8 c5 6a 81 \
+        6d bc 1b 26 77 61 95 5b c5
+        """.hexadecimalToData()
+        let testPlaintext = """
+        41 20 63 69 70 68 65 72 20 73 79 73 74 65 6d 20 6d 75 73 74 20 6e 6f \
+        74 20 62 65 20 72 65 71 75 69 72 65 64 20 74 6f 20 62 65 20 73 65 63 \
+        72 65 74 2c 20 61 6e 64 20 69 74 20 6d 75 73 74 20 62 65 20 61 62 6c \
+        65 20 74 6f 20 66 61 6c 6c 20 69 6e 74 6f 20 74 68 65 20 68 61 6e 64 \
+        73 20 6f 66 20 74 68 65 20 65 6e 65 6d 79 20 77 69 74 68 6f 75 74 20 \
+        69 6e 63 6f 6e 76 65 6e 69 65 6e 63 65
+        """.hexadecimalToData()
 
         let context = SymmetricDecryptionContext (
             ciphertext: ciphertext!,

--- a/Tests/AESEncrypterTests.swift
+++ b/Tests/AESEncrypterTests.swift
@@ -101,8 +101,18 @@ class AESEncrypterTests: RSACryptoTestCase {
 
     /// Tests the `AES` encryption implementation for AES_256_CBC_HMAC_SHA_512 with the test data provided in the [RFC-7518](https://tools.ietf.org/html/rfc7518#appendix-B.3).
     func testEncryptingA256CBCHS512() {
-        let plaintext = "41 20 63 69 70 68 65 72 20 73 79 73 74 65 6d 20 6d 75 73 74 20 6e 6f 74 20 62 65 20 72 65 71 75 69 72 65 64 20 74 6f 20 62 65 20 73 65 63 72 65 74 2c 20 61 6e 64 20 69 74 20 6d 75 73 74 20 62 65 20 61 62 6c 65 20 74 6f 20 66 61 6c 6c 20 69 6e 74 6f 20 74 68 65 20 68 61 6e 64 73 20 6f 66 20 74 68 65 20 65 6e 65 6d 79 20 77 69 74 68 6f 75 74 20 69 6e 63 6f 6e 76 65 6e 69 65 6e 63 65".hexadecimalToData()!
-        let additionalAuthenticatedData = "54 68 65 20 73 65 63 6f 6e 64 20 70 72 69 6e 63 69 70 6c 65 20 6f 66 20 41 75 67 75 73 74 65 20 4b 65 72 63 6b 68 6f 66 66 73".hexadecimalToData()!
+        let plaintext = """
+        41 20 63 69 70 68 65 72 20 73 79 73 74 65 6d 20 6d 75 73 74 20 6e 6f \
+        74 20 62 65 20 72 65 71 75 69 72 65 64 20 74 6f 20 62 65 20 73 65 63 \
+        72 65 74 2c 20 61 6e 64 20 69 74 20 6d 75 73 74 20 62 65 20 61 62 6c \
+        65 20 74 6f 20 66 61 6c 6c 20 69 6e 74 6f 20 74 68 65 20 68 61 6e 64 \
+        73 20 6f 66 20 74 68 65 20 65 6e 65 6d 79 20 77 69 74 68 6f 75 74 20 \
+        69 6e 63 6f 6e 76 65 6e 69 65 6e 63 65
+        """.hexadecimalToData()!
+        let additionalAuthenticatedData = """
+        54 68 65 20 73 65 63 6f 6e 64 20 70 72 69 6e 63 69 70 6c 65 20 6f 66 \
+        20 41 75 67 75 73 74 65 20 4b 65 72 63 6b 68 6f 66 66 73
+        """.hexadecimalToData()!
 
         let cek = try! SecureRandom.generate(count: SymmetricKeyAlgorithm.A256CBCHS512.keyLength)
         let encrypter = AESEncrypter(algorithm: .A256CBCHS512)

--- a/Tests/ASN1DERParsingTests.swift
+++ b/Tests/ASN1DERParsingTests.swift
@@ -100,11 +100,11 @@ class ASN1DERParsingTests: XCTestCase {
     func testParsingIntTLVLong() {
         let tlv = intTLVLong
 
-        let (tag, length, value) = try! tlv.nextTLVTriplet()
+        let triplet = try! tlv.nextTLVTriplet()
 
-        XCTAssertEqual(tag, 0x02)
-        XCTAssertEqual(length, [ 0x81, 0x81 ])
-        XCTAssertEqual(value, [
+        XCTAssertEqual(triplet.tag, 0x02)
+        XCTAssertEqual(triplet.length, [ 0x81, 0x81 ])
+        XCTAssertEqual(triplet.value, [
             0x00,
             0x8f, 0xe2, 0x41, 0x2a, 0x08, 0xe8, 0x51, 0xa8, 0x8c, 0xb3, 0xe8, 0x53, 0xe7, 0xd5, 0x49, 0x50,
             0xb3, 0x27, 0x8a, 0x2b, 0xcb, 0xea, 0xb5, 0x42, 0x73, 0xea, 0x02, 0x57, 0xcc, 0x65, 0x33, 0xee,
@@ -120,21 +120,21 @@ class ASN1DERParsingTests: XCTestCase {
     func testParsingIntTLVShort() {
         let tlv = intTLVShort
 
-        let (tag, length, value) = try! tlv.nextTLVTriplet()
+        let triplet = try! tlv.nextTLVTriplet()
 
-        XCTAssertEqual(tag, 0x02)
-        XCTAssertEqual(length, [ 0x01 ])
-        XCTAssertEqual(value, [ 0x03 ])
+        XCTAssertEqual(triplet.tag, 0x02)
+        XCTAssertEqual(triplet.length, [ 0x01 ])
+        XCTAssertEqual(triplet.value, [ 0x03 ])
     }
 
     func testParsingSequenceTLV() {
         let tlv = sequenceTLV
 
-        let (tag, length, value) = try! tlv.nextTLVTriplet()
+        let triplet = try! tlv.nextTLVTriplet()
 
-        XCTAssertEqual(tag, 0x30)
-        XCTAssertEqual(length, [ 0x82, 0x01, 0x0a ])
-        XCTAssertEqual(value, [
+        XCTAssertEqual(triplet.tag, 0x30)
+        XCTAssertEqual(triplet.length, [ 0x82, 0x01, 0x0a ])
+        XCTAssertEqual(triplet.value, [
             0x02, 0x82, 0x01, 0x01, 0x00, 0x88, 0x00, 0xf3, 0xc4, 0xc2, 0x7e, 0x97, 0xf3,
             0x48, 0x54, 0xf6, 0xea, 0xcf, 0xd7, 0xa8, 0x05, 0xe9, 0xd4, 0x08, 0x25, 0x22,
             0x34, 0xd7, 0xd9, 0xdf, 0xb7, 0x3a, 0x81, 0x42, 0x70, 0x58, 0x47, 0xc9, 0x47,

--- a/Tests/ASN1DERParsingTests.swift
+++ b/Tests/ASN1DERParsingTests.swift
@@ -25,7 +25,7 @@ import XCTest
 @testable import JOSESwift
 
 extension ASN1DERParsingError: Equatable {
-    public static func ==(lhs: ASN1DERParsingError, rhs: ASN1DERParsingError) -> Bool {
+    public static func == (lhs: ASN1DERParsingError, rhs: ASN1DERParsingError) -> Bool {
         switch (lhs, rhs) {
         case (.incorrectLengthFieldLength, .incorrectLengthFieldLength):
             return true

--- a/Tests/JWECompressionTests.swift
+++ b/Tests/JWECompressionTests.swift
@@ -14,7 +14,11 @@ class JWECompressionTests: RSACryptoTestCase {
     let data = "So Secret! 🔥🌵".data(using: .utf8)!
     let compressedDataBase64URLEncodedString = "C85XCE5NLkotUVT4MH_K0g_ze7YCAA"
 
-    let jweSerializedNotSupportedZipHeaderValue = "eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwiemlwIjoiR1pJUCJ9..I62WKaitlHoJ-Kz3zvQ-Tw.Tu9hk_AMRMRTc8ggsoWifFS979Nz8xt-xx4FpF6waeE.w7c8eAGXpUD3tNskLzdl17s4vsCCSUwe5bRFpJg1kUs"
+    let jweSerializedNotSupportedZipHeaderValue = """
+        eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwiemlwIjoiR1pJUCJ9..I62W\
+        KaitlHoJ-Kz3zvQ-Tw.Tu9hk_AMRMRTc8ggsoWifFS979Nz8xt-xx4FpF6waeE.w7c8eAG\
+        XpUD3tNskLzdl17s4vsCCSUwe5bRFpJg1kUs
+        """
 
     @available(*, deprecated)
     func testRoundtripWithLegacyDecrypter() {

--- a/Tests/JWEDeserializationTests.swift
+++ b/Tests/JWEDeserializationTests.swift
@@ -26,12 +26,28 @@ import XCTest
 
 class JWEDeserializationTests: XCTestCase {
 
-    let serialized = "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ.OKOawDo13gRp2ojaHV7LFpZcgV7T6DVZKTyKOMTYUmKoTCVJRgckCL9kiMT03JGeipsEdY3mx_etLbbWSrFr05kLzcSr4qKAq7YN7e9jwQRb23nfa6c9d-StnImGyFDbSv04uVuxIp5Zms1gNxKKK2Da14B8S4rzVRltdYwam_lDp5XnZAYpQdb76FdIKLaVmqgfwX7XWRxv2322i-vDxRfqNzo_tETKzpVLzfiwQyeyPGLBIO56YJ7eObdv0je81860ppamavo35UgoRdbYaBcoh9QcfylQr66oc6vFWXRcZ_ZT2LawVCWTIy3brGPi6UklfCpIMfIjf7iGdXKHzg.48V1_ALb6US04U3b.5eym8TW_c8SuK0ltJ3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX_EFShS8iB7j6jiSdiwkIr3ajwQzaBtQD_A.XFBoMYUZodetZdvTiFvSkQ"
+    let serialized = """
+    eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ.OKOawDo13gRp2ojaHV7LFpZcgV7\
+    T6DVZKTyKOMTYUmKoTCVJRgckCL9kiMT03JGeipsEdY3mx_etLbbWSrFr05kLzcSr4qKAq7YN7\
+    e9jwQRb23nfa6c9d-StnImGyFDbSv04uVuxIp5Zms1gNxKKK2Da14B8S4rzVRltdYwam_lDp5X\
+    nZAYpQdb76FdIKLaVmqgfwX7XWRxv2322i-vDxRfqNzo_tETKzpVLzfiwQyeyPGLBIO56YJ7eO\
+    bdv0je81860ppamavo35UgoRdbYaBcoh9QcfylQr66oc6vFWXRcZ_ZT2LawVCWTIy3brGPi6Uk\
+    lfCpIMfIjf7iGdXKHzg.48V1_ALb6US04U3b.5eym8TW_c8SuK0ltJ3rpYIzOeDQz7TALvtu6U\
+    G9oMo4vpzs9tX_EFShS8iB7j6jiSdiwkIr3ajwQzaBtQD_A.XFBoMYUZodetZdvTiFvSkQ
+    """
 
     let expectedHeader = "{\"alg\":\"RSA-OAEP\",\"enc\":\"A256GCM\"}".data(using: .utf8)!
-    let expectedEncryptedKey = Data(base64Encoded: "OKOawDo13gRp2ojaHV7LFpZcgV7T6DVZKTyKOMTYUmKoTCVJRgckCL9kiMT03JGeipsEdY3mx/etLbbWSrFr05kLzcSr4qKAq7YN7e9jwQRb23nfa6c9d+StnImGyFDbSv04uVuxIp5Zms1gNxKKK2Da14B8S4rzVRltdYwam/lDp5XnZAYpQdb76FdIKLaVmqgfwX7XWRxv2322i+vDxRfqNzo/tETKzpVLzfiwQyeyPGLBIO56YJ7eObdv0je81860ppamavo35UgoRdbYaBcoh9QcfylQr66oc6vFWXRcZ/ZT2LawVCWTIy3brGPi6UklfCpIMfIjf7iGdXKHzg==")!
+    let expectedEncryptedKey = Data(base64Encoded: """
+    OKOawDo13gRp2ojaHV7LFpZcgV7T6DVZKTyKOMTYUmKoTCVJRgckCL9kiMT03JGeipsEdY3mx/\
+    etLbbWSrFr05kLzcSr4qKAq7YN7e9jwQRb23nfa6c9d+StnImGyFDbSv04uVuxIp5Zms1gNxKK\
+    K2Da14B8S4rzVRltdYwam/lDp5XnZAYpQdb76FdIKLaVmqgfwX7XWRxv2322i+vDxRfqNzo/tE\
+    TKzpVLzfiwQyeyPGLBIO56YJ7eObdv0je81860ppamavo35UgoRdbYaBcoh9QcfylQr66oc6vF\
+    WXRcZ/ZT2LawVCWTIy3brGPi6UklfCpIMfIjf7iGdXKHzg==
+    """)!
     let expectedInitializationVector = Data(base64Encoded: "48V1/ALb6US04U3b")!
-    let expectedCiphertext = Data(base64Encoded: "5eym8TW/c8SuK0ltJ3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX/EFShS8iB7j6jiSdiwkIr3ajwQzaBtQD/A")!
+    let expectedCiphertext = Data(base64Encoded: """
+    5eym8TW/c8SuK0ltJ3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX/EFShS8iB7j6jiSdiwkIr3ajwQzaBtQD/A
+    """)!
     let expectedAuthTag = Data(base64Encoded: "XFBoMYUZodetZdvTiFvSkQ==")!
 
     func testDeserialization() {

--- a/Tests/JWEDirectEncryptionTests.swift
+++ b/Tests/JWEDirectEncryptionTests.swift
@@ -60,6 +60,7 @@ class JWEDirectEncryptionTests: RSACryptoTestCase {
         try! XCTAssertEqual(JWE(compactSerialization: serialization).decrypt(with: symmetricKey).data(), data)
     }
 
+    @available(*, deprecated)
     func testRoundtripA256CBCHS512() {
         let symmetricKey = try! SecureRandom.generate(count: SymmetricKeyAlgorithm.A256CBCHS512.keyLength)
 

--- a/Tests/JWSECTests.swift
+++ b/Tests/JWSECTests.swift
@@ -33,6 +33,7 @@ class JWSECTests: ECCryptoTestCase {
         super.tearDown()
     }
 
+    @available(*, deprecated)
     func testSignAndSerialize() {
         allTestData.forEach { testData in
             self.performTestECSign(testData: testData)
@@ -47,6 +48,7 @@ class JWSECTests: ECCryptoTestCase {
 
     // MARK: - EC Tests
 
+    @available(*, deprecated)
     private func performTestECSign(testData: ECTestKeyData) {
         let algorithm = SignatureAlgorithm(rawValue: testData.signatureAlgorithm)!
         let header = JWSHeader(algorithm: algorithm)

--- a/Tests/JWSValidationTests.swift
+++ b/Tests/JWSValidationTests.swift
@@ -239,7 +239,7 @@ class JWSValidationTests: RSACryptoTestCase {
 }
 
 extension JOSESwiftError: Equatable {
-    public static func ==(lhs: JOSESwiftError, rhs: JOSESwiftError) -> Bool {
+    public static func == (lhs: JOSESwiftError, rhs: JOSESwiftError) -> Bool {
         switch (lhs, rhs) {
         case (.verifyingFailed(let lhs), .verifyingFailed(let rhs)):
             return lhs == rhs

--- a/Tests/RSADecrypterTests.swift
+++ b/Tests/RSADecrypterTests.swift
@@ -81,8 +81,12 @@ class RSADecrypterTests: RSACryptoTestCase {
         8GmvJ5UwA==
         """
 
-    let rsa1DecryptionError = RSAError.decryptingFailed(description: "The operation couldn’t be completed. (OSStatus error -50 - RSAdecrypt wrong input (err -1))") // adjusted for RSA-OAEP-256 error having a differe 'err' number
-    let rsaOAEPDecryptionError = RSAError.decryptingFailed(description: "The operation couldn’t be completed. (OSStatus error -50 - RSAdecrypt wrong input (err -27))")
+    let rsa1DecryptionError = RSAError.decryptingFailed(description: """
+        The operation couldn’t be completed. (OSStatus error -50 - RSAdecrypt wrong input (err -1))
+        """) // adjusted for RSA-OAEP-256 error having a differe 'err' number
+    let rsaOAEPDecryptionError = RSAError.decryptingFailed(description: """
+        The operation couldn’t be completed. (OSStatus error -50 - RSAdecrypt wrong input (err -27))
+        """)
 
     /// Dictionary of decryption errors for each available Asymmetric key algorithm
     lazy var decryptionErrors: [String: RSAError] = {

--- a/Tests/RSAEncrypterTests.swift
+++ b/Tests/RSAEncrypterTests.swift
@@ -25,7 +25,7 @@ import XCTest
 @testable import JOSESwift
 
 extension RSAError: Equatable {
-    public static func ==(lhs: RSAError, rhs: RSAError) -> Bool {
+    public static func == (lhs: RSAError, rhs: RSAError) -> Bool {
         switch (lhs, rhs) {
         case (.cipherTextLenghtNotSatisfied, .cipherTextLenghtNotSatisfied):
             return true

--- a/Tests/RSAEncrypterTests.swift
+++ b/Tests/RSAEncrypterTests.swift
@@ -109,7 +109,7 @@ class RSAEncrypterTests: RSACryptoTestCase {
         }
     }
 
-    func testEncryptingWithAliceAndBobKey() {
+    func testEncryptingWithAliceAndBobKey() throws {
         guard
             let publicKeyAlice2048 = publicKeyAlice2048,
             let publicKeyBob2048 = publicKeyBob2048 else {
@@ -126,14 +126,8 @@ class RSAEncrypterTests: RSACryptoTestCase {
             let encrypterAlice = RSAEncrypter(algorithm: algorithm, publicKey: publicKeyAlice2048)
             let encrypterBob = RSAEncrypter(algorithm: algorithm, publicKey: publicKeyBob2048)
 
-            guard let cipherTextAlice = try? encrypterAlice.encrypt(message.data(using: .utf8)!) else {
-                XCTFail()
-                return
-            }
-            guard let cipherTextBob = try? encrypterBob.encrypt(message.data(using: .utf8)!) else {
-                XCTFail()
-                return
-            }
+            let cipherTextAlice = try encrypterAlice.encrypt(message.data(using: .utf8)!)
+            let cipherTextBob = try encrypterBob.encrypt(message.data(using: .utf8)!)
 
             // Cipher texts have to differ (different keys)
             XCTAssertNotEqual(cipherTextAlice, cipherTextBob)

--- a/Tests/RSASignerTests.swift
+++ b/Tests/RSASignerTests.swift
@@ -25,7 +25,13 @@ import XCTest
 @testable import JOSESwift
 
 class RSASignerTests: RSACryptoTestCase {
-    let signatureBase64URL = "Zs9rmMw-za1uXpUS2VIOcEHaMuzQl6fBCi_40kRVIE0GUruWSvpHro1oXhGwf7HqKPLx_LM8bLPCORWi9OWU4swZHY8p-GR5rhLLs2XkdIvI5kdbikr7pZOsC9NaxJKMWAntKbTZY6exkoU8vM6xL9MQtH8QFLXTjI-ZvAXbp2Ws9CnIcvOPFqAupuUKADFRpSlODlsXy71CJ3iQeBaPfHvLk61jdW6hgHYj-0WYmrFhiF1dI9MZf9J3ApdKFsW0WFuxa8Y47HlCirEOb3lz7vm8o9lNBTnt0dpWOZMTU6lHuTBgiXvyENzJoKJymVsUbMmy-2LNejmVpPt1Pm3zrA"
+    let signatureBase64URL = """
+    Zs9rmMw-za1uXpUS2VIOcEHaMuzQl6fBCi_40kRVIE0GUruWSvpHro1oXhGwf7HqKPLx_LM8bL\
+    PCORWi9OWU4swZHY8p-GR5rhLLs2XkdIvI5kdbikr7pZOsC9NaxJKMWAntKbTZY6exkoU8vM6x\
+    L9MQtH8QFLXTjI-ZvAXbp2Ws9CnIcvOPFqAupuUKADFRpSlODlsXy71CJ3iQeBaPfHvLk61jdW\
+    6hgHYj-0WYmrFhiF1dI9MZf9J3ApdKFsW0WFuxa8Y47HlCirEOb3lz7vm8o9lNBTnt0dpWOZMT\
+    U6lHuTBgiXvyENzJoKJymVsUbMmy-2LNejmVpPt1Pm3zrA
+    """
 
     override func setUp() {
         super.setUp()

--- a/Tests/RSASignerTests.swift
+++ b/Tests/RSASignerTests.swift
@@ -42,10 +42,7 @@ class RSASignerTests: RSACryptoTestCase {
     }
 
     func testSigning() {
-        guard privateKeyAlice2048 != nil else {
-            XCTFail()
-            return
-        }
+        XCTAssertNotNil(privateKeyAlice2048)
 
         let signer = RSASigner(algorithm: .RS512, privateKey: privateKeyAlice2048!)
         let signature = try! signer.sign(message.data(using: .utf8)!)

--- a/Tests/SecKeyECPrivateKeyTests.swift
+++ b/Tests/SecKeyECPrivateKeyTests.swift
@@ -55,18 +55,15 @@ class SecKeyECPrivateKeyTests: ECCryptoTestCase {
         }
     }
 
-    func testPrivateKeyFromPrivateComponents() {
-        allTestData.forEach { testData in
+    func testPrivateKeyFromPrivateComponents() throws {
+        try allTestData.forEach { testData in
             let components = (
                     testData.expectedCurveType,
                     testData.expectedXCoordinate,
                     testData.expectedYCoordinate,
                     testData.expectedPrivateOctetString
             )
-            guard let secKey = try? SecKey.representing(ecPrivateKeyComponents: components) else {
-                XCTFail()
-                return
-            }
+            let secKey = try SecKey.representing(ecPrivateKeyComponents: components)
 
             let data = SecKeyCopyExternalRepresentation(secKey, nil)! as Data
             let dataExpected = SecKeyCopyExternalRepresentation(testData.privateKey, nil)! as Data

--- a/Tests/SecKeyECPublicKeyTests.swift
+++ b/Tests/SecKeyECPublicKeyTests.swift
@@ -53,13 +53,10 @@ class SecKeyECPublicKeyTests: ECCryptoTestCase {
         }
     }
 
-    func testPublicKeyFromPublicComponents() {
-        allTestData.forEach { testData in
+    func testPublicKeyFromPublicComponents() throws {
+        try allTestData.forEach { testData in
             let components = (testData.expectedCurveType, testData.expectedXCoordinate, testData.expectedYCoordinate)
-            guard let secKey = try? SecKey.representing(ecPublicKeyComponents: components) else {
-                XCTFail()
-                return
-            }
+            let secKey = try SecKey.representing(ecPublicKeyComponents: components)
 
             let data = SecKeyCopyExternalRepresentation(secKey, nil)! as Data
             let dataExpected = SecKeyCopyExternalRepresentation(testData.publicKey, nil)! as Data

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,7 +9,7 @@ end
 
 desc "Lint Swift files"
 lane :lint do
-  swiftlint()
+  swiftlint
 end
 
 desc "Format Swift files"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,8 +9,7 @@ end
 
 desc "Lint Swift files"
 lane :lint do
-  # Todo: Don't ignore exit status (#98)
-  swiftlint(ignore_exit_status: true)
+  swiftlint()
 end
 
 desc "Format Swift files"


### PR DESCRIPTION
Hey, it's been a while, so I thought I start tackling #98.

So far, this pull request
* runs SwiftLint autocorrection
* adds a SwiftLint build phase to trigger warnings in Xcode
* fixes/disables the errors that prevent the project from building
* removes the `ignore_exit_status` from the fastlane action

Since this is already getting kind of big, I think it's better to fix the remaining 254 warnings bit by bit.

In order to make this as smooth as possible, we should do one of the following:
1. Disable the offending rules, fix and re-enable them later
1. Remove the SwiftLint build phase, fix the warnings and add it again
1. Disable the biggest offenders (`xctfail_message` and `line_length`), fix them later, and fix the remaining 30 issues now