### PR TITLE
Add support for EC256 keys that are stored inside the Secure Enclave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Add your changes here.
 - Update to Swift 5 [#154](https://github.com/airsidemobile/JOSESwift/pull/154)) via [@daniel-mohemian](https://github.com/daniel-mohemian)
 - Adds pull request linting in Danger ([#153](https://github.com/airsidemobile/JOSESwift/pull/153)) via [@daniel-mohemian](https://github.com/daniel-mohemian)
 - Adds a SwiftLint build phase and fixes many violations ([#151](https://github.com/airsidemobile/JOSESwift/pull/151)) via [@xavierLowmiller](https://github.com/xavierLowmiller)
+- Add support for EC256 keys that are stored inside the Secure Enclave ([#156](https://github.com/airsidemobile/JOSESwift/pull/156)) via [@mschwaig](https://github.com/mschwaig)
 
 ## [1.8.0] - 2019-03-18
 


### PR DESCRIPTION
This PR changes the EC crypto implemenation to use `SecKeyCreateSignature` and `SecKeyVerfiySignature` for signature creation and verification and adds the required conversions to and from BER encoded ASN.1 format for the signatures.
It also introduces negative tests for EC signature verification, to detect trivial false acceptances for the signature validation. This is important because the tests for the signing also rely on the validation implementation.

See #155 for the discussion which lead to this PR.

Please be thorough with the iOS side of the review, since I do not have that much experience as developer for iOS.