### PR TITLE
Add tests for conversion from and to ASN.1 Integers for EC signatures

### DIFF
--- a/JOSESwift.xcodeproj/project.pbxproj
+++ b/JOSESwift.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		8A30B8F822118FD0001834E3 /* DeflateWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A30B8F722118FD0001834E3 /* DeflateWrapper.swift */; };
 		8A30B8FA22118FE6001834E3 /* JWECompressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A30B8F922118FE6001834E3 /* JWECompressionTests.swift */; };
 		8A4B08B22213FF0600828536 /* Compressor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4B08B12213FF0600828536 /* Compressor.swift */; };
+		9665A24722B0F3E100EAC14A /* ECAsn1IntegerConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9665A24622B0F3E100EAC14A /* ECAsn1IntegerConversionTests.swift */; };
 		C803EFE51FA77E3000B71335 /* JWSRSATests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C803EFE41FA77E3000B71335 /* JWSRSATests.swift */; };
 		C803EFE91FA7893A00B71335 /* JWSHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C803EFE81FA7893A00B71335 /* JWSHeaderTests.swift */; };
 		C803EFED1FA8849C00B71335 /* JWERSATests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C803EFEC1FA8849C00B71335 /* JWERSATests.swift */; };
@@ -206,6 +207,7 @@
 		8A30B8F722118FD0001834E3 /* DeflateWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeflateWrapper.swift; sourceTree = "<group>"; };
 		8A30B8F922118FE6001834E3 /* JWECompressionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JWECompressionTests.swift; sourceTree = "<group>"; };
 		8A4B08B12213FF0600828536 /* Compressor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Compressor.swift; sourceTree = "<group>"; };
+		9665A24622B0F3E100EAC14A /* ECAsn1IntegerConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ECAsn1IntegerConversionTests.swift; sourceTree = "<group>"; };
 		C803EFE41FA77E3000B71335 /* JWSRSATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWSRSATests.swift; sourceTree = "<group>"; };
 		C803EFE81FA7893A00B71335 /* JWSHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWSHeaderTests.swift; sourceTree = "<group>"; };
 		C803EFEC1FA8849C00B71335 /* JWERSATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWERSATests.swift; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 		65125A2C1FBF6B79007CF3AE /* JWS */ = {
 			isa = PBXGroup;
 			children = (
+				9665A24622B0F3E100EAC14A /* ECAsn1IntegerConversionTests.swift */,
 				6575696C203EF9CE004A0EFD /* JWSValidationTests.swift */,
 				652C61391FD99A3300578E2A /* JWSSigningInputTest.swift */,
 				C803EFE81FA7893A00B71335 /* JWSHeaderTests.swift */,
@@ -644,6 +647,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9665A24722B0F3E100EAC14A /* ECAsn1IntegerConversionTests.swift in Sources */,
 				65826AB420286B3A00AFFC46 /* JWKRSAEncodingTests.swift in Sources */,
 				C83070051FD1B7390068C5CB /* AESDecrypterTests.swift in Sources */,
 				C803EFE91FA7893A00B71335 /* JWSHeaderTests.swift in Sources */,

--- a/JOSESwift/Sources/CryptoImplementation/EC.swift
+++ b/JOSESwift/Sources/CryptoImplementation/EC.swift
@@ -105,7 +105,7 @@ fileprivate extension Data {
     func withLengthFixedTo(_ octetLength: Int) -> Data {
         let varLength = self.count
         if varLength > octetLength + 1 {
-            fatalError("Unable to parse ASN.1 Integer")
+            fatalError("ASN.1 integer is \(varLength) bytes long when it should be < \(octetLength + 1).")
         }
         if varLength == octetLength + 1 {
             assert(self.first == 0)
@@ -118,7 +118,7 @@ fileprivate extension Data {
             // pad to fixed length using 0x00 bytes
             return Data(count: octetLength - varLength) + self
         }
-        fatalError("Unable to parse ASN.1 Integer")
+        fatalError("Unable to parse ASN.1 integer. This should be unreachable.")
     }
 
     func fixedLengthToAsn1() -> Data {
@@ -213,7 +213,7 @@ internal struct EC {
 
             return fixlenR + fixlenS
         } catch {
-            throw ECError.signingFailed(description: "Could not unpack ASN.1 EC signature")
+            throw ECError.signingFailed(description: "Could not unpack ASN.1 EC signature.")
         }
     }
 

--- a/JOSESwift/Sources/CryptoImplementation/EC.swift
+++ b/JOSESwift/Sources/CryptoImplementation/EC.swift
@@ -95,48 +95,6 @@ public enum ECCurveType: String, Codable {
     }
 }
 
-// Converting integers to and from DER encoded ASN.1 as described here:
-// https://docs.microsoft.com/en-us/windows/desktop/seccertenroll/about-integer
-// This conversion is required because the Secure Enclave only supports generating ASN.1 encoded signatures,
-// while the JWS Standard requires raw signatures, where the R and S values unsigned integers with a fixed length:
-// https://github.com/airsidemobile/JOSESwift/pull/156#discussion_r292370209
-// https://tools.ietf.org/html/rfc7515#appendix-A.3.1
-fileprivate extension Data {
-    func withLengthFixedTo(_ octetLength: Int) -> Data {
-        let varLength = self.count
-        if varLength > octetLength + 1 {
-            fatalError("ASN.1 integer is \(varLength) bytes long when it should be < \(octetLength + 1).")
-        }
-        if varLength == octetLength + 1 {
-            assert(self.first == 0)
-            return self.dropFirst()
-        }
-        if varLength == octetLength {
-            return self
-        }
-        if varLength < octetLength {
-            // pad to fixed length using 0x00 bytes
-            return Data(count: octetLength - varLength) + self
-        }
-        fatalError("Unable to parse ASN.1 integer. This should be unreachable.")
-    }
-
-    func fixedLengthToAsn1() -> Data {
-        assert(self.count > 0)
-        let msb: UInt8 = 0b1000_0000
-        // drop all leading zero bytes
-        let varlen = self.drop { $0 == 0}
-        guard let firstNonZero = varlen.first else {
-            // all bytes were zero so the encoded value is zero
-            return Data(count: 1)
-        }
-        if (firstNonZero & msb) == msb {
-            return Data(count: 1) + varlen
-        }
-        return varlen
-    }
-}
-
 fileprivate extension SignatureAlgorithm {
 
     var secKeyAlgorithm: SecKeyAlgorithm? {
@@ -208,8 +166,8 @@ internal struct EC {
             let ecSignature = try ecSignatureTLV.read(.sequence)
             let varlenR = try Data(ecSignature.read(.integer))
             let varlenS = try Data(ecSignature.skip(.integer).read(.integer))
-            let fixlenR = varlenR.withLengthFixedTo(curveType.coordinateOctetLength)
-            let fixlenS = varlenS.withLengthFixedTo(curveType.coordinateOctetLength)
+            let fixlenR = Asn1IntegerConversion.toRaw(varlenR, of: curveType.coordinateOctetLength)
+            let fixlenS = Asn1IntegerConversion.toRaw(varlenS, of: curveType.coordinateOctetLength)
 
             return fixlenR + fixlenS
         } catch {
@@ -240,9 +198,9 @@ internal struct EC {
 
         // pack raw signature as specified for JWS into BER encoded ASN.1 format
         let fixlenR = signature.prefix(curveType.coordinateOctetLength)
-        let varlenR = [UInt8](fixlenR.fixedLengthToAsn1())
+        let varlenR = [UInt8](Asn1IntegerConversion.fromRaw(fixlenR))
         let fixlenS = signature.suffix(curveType.coordinateOctetLength)
-        let varlenS = [UInt8](fixlenS.fixedLengthToAsn1())
+        let varlenS = [UInt8](Asn1IntegerConversion.fromRaw(fixlenS))
         let asn1Signature = Data((varlenR.encode(as: .integer) + varlenS.encode(as: .integer)).encode(as: .sequence))
 
         var cfErrorRef: Unmanaged<CFError>?
@@ -251,6 +209,48 @@ internal struct EC {
             throw ECError.verifyingFailed(description: "Error verifying signature. (CFError: \(error.takeRetainedValue()))")
         }
         return isValid
+    }
+
+    // Converting integers to and from DER encoded ASN.1 as described here:
+    // https://docs.microsoft.com/en-us/windows/desktop/seccertenroll/about-integer
+    // This conversion is required because the Secure Enclave only supports generating ASN.1 encoded signatures,
+    // while the JWS Standard requires raw signatures, where the R and S are unsigned integers with a fixed length:
+    // https://github.com/airsidemobile/JOSESwift/pull/156#discussion_r292370209
+    // https://tools.ietf.org/html/rfc7515#appendix-A.3.1
+    internal struct Asn1IntegerConversion {
+        static func toRaw(_ data: Data, of fixedLength: Int) -> Data {
+            let varLength = data.count
+            if varLength > fixedLength + 1 {
+                fatalError("ASN.1 integer is \(varLength) bytes long when it should be < \(fixedLength + 1).")
+            }
+            if varLength == fixedLength + 1 {
+                assert(data.first == 0)
+                return data.dropFirst()
+            }
+            if varLength == fixedLength {
+                return data
+            }
+            if varLength < fixedLength {
+                // pad to fixed length using 0x00 bytes
+                return Data(count: fixedLength - varLength) + data
+            }
+            fatalError("Unable to parse ASN.1 integer. This should be unreachable.")
+        }
+
+        static func fromRaw(_ data: Data) -> Data {
+            assert(data.count > 0)
+            let msb: UInt8 = 0b1000_0000
+            // drop all leading zero bytes
+            let varlen = data.drop { $0 == 0}
+            guard let firstNonZero = varlen.first else {
+                // all bytes were zero so the encoded value is zero
+                return Data(count: 1)
+            }
+            if (firstNonZero & msb) == msb {
+                return Data(count: 1) + varlen
+            }
+            return varlen
+        }
     }
 
 }

--- a/Tests/ECAsn1IntegerConversionTests.swift
+++ b/Tests/ECAsn1IntegerConversionTests.swift
@@ -1,6 +1,5 @@
-// swiftlint:disable force_unwrapping
 //
-//  ECAsn1ConversionTests.swift
+//  ECAsn1IntegerConversionTests.swift
 //  Tests
 //
 //  Created by Martin Schwaighofer on 12.06.19.
@@ -91,7 +90,7 @@ class ECAsn1IntegerConversionTests: XCTestCase {
 
     func testDecodeFourByteInts() {
         for int in fourByteInts {
-            XCTAssertEqual (EC.Asn1IntegerConversion.toRaw(int.asn1, of: 4), int.raw,  "Failure for \"\(int.description)\" example.")
+            XCTAssertEqual (EC.Asn1IntegerConversion.toRaw(int.asn1, of: 4), int.raw, "Failure for \"\(int.description)\" example.")
         }
     }
 

--- a/Tests/ECAsn1IntegerConversionTests.swift
+++ b/Tests/ECAsn1IntegerConversionTests.swift
@@ -99,6 +99,6 @@ class ECAsn1IntegerConversionTests: XCTestCase {
     }
 
     func testDecodeHugeInt() {
-        XCTAssertEqual (EC.Asn1IntegerConversion.fromRaw(hugeInt.asn1), hugeInt.raw)
+        XCTAssertEqual (EC.Asn1IntegerConversion.toRaw(hugeInt.asn1, of: 64), hugeInt.raw)
     }
 }

--- a/Tests/ECAsn1IntegerConversionTests.swift
+++ b/Tests/ECAsn1IntegerConversionTests.swift
@@ -1,0 +1,105 @@
+// swiftlint:disable force_unwrapping
+//
+//  ECAsn1ConversionTests.swift
+//  Tests
+//
+//  Created by Martin Schwaighofer on 12.06.19.
+//
+//  ---------------------------------------------------------------------------
+//  Copyright 2019 Airside Mobile Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ---------------------------------------------------------------------------
+
+import XCTest
+@testable import JOSESwift
+
+class ECAsn1IntegerConversionTests: XCTestCase {
+
+    struct TestInteger {
+        let raw: Data
+        let asn1: Data
+        let description: String
+    }
+
+    // one byte test integers
+    let oneByteInts = [
+        TestInteger(raw: Data([ 0x00 ]), asn1: Data ([ 0x00 ]), description: "0"),
+        TestInteger(raw: Data([ 0x01 ]), asn1: Data ([ 0x01 ]), description: "1"),
+        TestInteger(raw: Data([ 0x80 ]), asn1: Data ([ 0x00, 0x80 ]), description: "128")
+    ]
+
+    // four byte test integers
+    let fourByteInts = [
+        TestInteger(raw: Data([ 0x00, 0x00, 0x00, 0x00 ]), asn1: Data([ 0x00 ]), description: "0"),
+        TestInteger(raw: Data([ 0x00, 0x00, 0x00, 0x01 ]), asn1: Data([ 0x01 ]), description: "1"),
+        TestInteger(raw: Data([ 0x00, 0x00, 0x00, 0x80 ]), asn1: Data([ 0x00, 0x80 ]), description: "128"),
+        TestInteger(raw: Data([ 0x9B, 0x81, 0x03, 0x63 ]), asn1: Data ([ 0x00, 0x9B, 0x81, 0x03, 0x63 ]), description: "high leading bit"),
+        TestInteger(raw: Data([ 0x11, 0x81, 0x03, 0x63 ]), asn1: Data ([ 0x11, 0x81, 0x03, 0x63 ]), description: "low leading bit"),
+        TestInteger(raw: Data([ 0x00, 0x01, 0x03, 0x63 ]), asn1: Data ([ 0x01, 0x03, 0x63 ]), description: "low leading byte followed by low leading bit"),
+        TestInteger(raw: Data([ 0x00, 0x81, 0x03, 0x63 ]), asn1: Data ([ 0x00, 0x81, 0x03, 0x63 ]), description: "low leading byte followed by high leading bit"),
+        TestInteger(raw: Data([ 0x00, 0x00, 0x03, 0x63 ]), asn1: Data ([ 0x03, 0x63 ]), description: "low leading bytes followed by low leading bit"),
+        TestInteger(raw: Data([ 0x00, 0x00, 0x83, 0x63 ]), asn1: Data ([ 0x00, 0x83, 0x63 ]), description: "low leading bytes followed by high leading bit"),
+        TestInteger(raw: Data([ 0x11, 0x00, 0x00, 0x63 ]), asn1: Data ([ 0x11, 0x00, 0x00, 0x63 ]), description: "intermediary low bytes"),
+        TestInteger(raw: Data([ 0x9B, 0x81, 0x03, 0x00 ]), asn1: Data ([ 0x00, 0x9B, 0x81, 0x03, 0x00 ]), description: "low tailing bytes")
+    ]
+
+    // 64 byte tests
+    let hugeInt = TestInteger(
+        raw: Data([
+            0x06, 0xA5, 0x28, 0x53, 0xE9, 0x71, 0x64, 0x9F, 0x15, 0x20, 0x73, 0x7D, 0x9F, 0xF7, 0xE8, 0x36,
+            0x86, 0xA0, 0x32, 0xD5, 0x73, 0xBD, 0x16, 0x2F, 0x0E, 0x0A, 0x71, 0xFD, 0x92, 0x93, 0x0E, 0x81,
+            0x57, 0x62, 0x29, 0xFC, 0x49, 0x7C, 0x80, 0x82, 0x24, 0xBE, 0x04, 0x07, 0xE9, 0x85, 0xF2, 0xE2,
+            0xBC, 0x22, 0xE9, 0xA9, 0xB9, 0xDB, 0x65, 0x64, 0x38, 0x07, 0x60, 0xB1, 0x7A, 0x20, 0x5E, 0x0D
+            ]),
+        asn1: Data ([
+            0x06, 0xA5, 0x28, 0x53, 0xE9, 0x71, 0x64, 0x9F, 0x15, 0x20, 0x73, 0x7D, 0x9F, 0xF7, 0xE8, 0x36,
+            0x86, 0xA0, 0x32, 0xD5, 0x73, 0xBD, 0x16, 0x2F, 0x0E, 0x0A, 0x71, 0xFD, 0x92, 0x93, 0x0E, 0x81,
+            0x57, 0x62, 0x29, 0xFC, 0x49, 0x7C, 0x80, 0x82, 0x24, 0xBE, 0x04, 0x07, 0xE9, 0x85, 0xF2, 0xE2,
+            0xBC, 0x22, 0xE9, 0xA9, 0xB9, 0xDB, 0x65, 0x64, 0x38, 0x07, 0x60, 0xB1, 0x7A, 0x20, 0x5E, 0x0D
+            ]),
+        description: "64 bytes (huge)"
+    )
+
+    func testEncodeOneByteInts() {
+        for int in oneByteInts {
+            XCTAssertEqual (EC.Asn1IntegerConversion.fromRaw(int.raw), int.asn1, "Failure for \"\(int.description)\" example.")
+        }
+    }
+
+    func testDecodeOneByteInts() {
+        for int in oneByteInts {
+            XCTAssertEqual (EC.Asn1IntegerConversion.toRaw(int.asn1, of: 1), int.raw, "Failure for \"\(int.description)\" example.")
+        }
+    }
+
+    func testEncodeFourByteInts() {
+        for int in fourByteInts {
+            XCTAssertEqual (EC.Asn1IntegerConversion.fromRaw(int.raw), int.asn1, "Failure for \"\(int.description)\" example.")
+        }
+    }
+
+    func testDecodeFourByteInts() {
+        for int in fourByteInts {
+            XCTAssertEqual (EC.Asn1IntegerConversion.toRaw(int.asn1, of: 4), int.raw,  "Failure for \"\(int.description)\" example.")
+        }
+    }
+
+    func testEncodeHugeInt() {
+        XCTAssertEqual (EC.Asn1IntegerConversion.fromRaw(hugeInt.raw), hugeInt.asn1)
+    }
+
+    func testDecodeHugeInt() {
+        XCTAssertEqual (EC.Asn1IntegerConversion.fromRaw(hugeInt.asn1), hugeInt.raw)
+    }
+}


### PR DESCRIPTION
This resolves #157 by

- adding tests for ASN.1 tests,

but also

- improves some error messages in the EC implementation and
- moves the conversion functions under test into an internal struct for now.

Moving the conversion logic into the`ECCurveType` like suggested in https://github.com/airsidemobile/JOSESwift/pull/156#discussion_r292876252 might still be a good idea, but I did not do this for now. Feel free to do that.