### PR TITLE
Extend JOSESwift Errors with localAuthentication

### DIFF
--- a/JOSESwift/Sources/CryptoImplementation/EC.swift
+++ b/JOSESwift/Sources/CryptoImplementation/EC.swift
@@ -160,7 +160,7 @@ internal struct EC {
                 let cfError = error.takeRetainedValue()
                 let errorDomain = CFErrorGetDomain(cfError)
                 let errorCode = CFErrorGetCode(cfError)
-                
+
                 if errorDomain == LAErrorDomain as CFErrorDomain {
                     throw ECError.localAuthenticationFailed(errorCode: errorCode)
                 }

--- a/JOSESwift/Sources/JOSESwiftError.swift
+++ b/JOSESwift/Sources/JOSESwiftError.swift
@@ -36,6 +36,7 @@ public enum JOSESwiftError: Error {
     case invalidCurveType
     case compressedCurvePointsUnsupported
     case invalidCurvePointOctetLength
+    case localAuthenticationFailed(errorCode: Int)
 
     // Compression erros
     case compressionFailed

--- a/JOSESwift/Sources/JWS.swift
+++ b/JOSESwift/Sources/JWS.swift
@@ -61,8 +61,17 @@ public struct JWS {
         do {
             self.signature = try signer.sign(header: header, payload: payload)
         } catch {
+            if let ecError = error as? ECError {
+                switch ecError {
+                case .localAuthenticationFailed(errorCode: let errorCode):
+                    throw JOSESwiftError.localAuthenticationFailed(errorCode: errorCode)
+                default:
+                    break
+                }
+            }
             throw JOSESwiftError.signingFailed(description: error.localizedDescription)
         }
+        
     }
 
     /// Constructs a JWS object from a given compact serialization string.
@@ -192,6 +201,7 @@ public struct JWS {
             return false
         }
     }
+    
 }
 
 extension JWS: CompactSerializable {

--- a/JOSESwift/Sources/JWS.swift
+++ b/JOSESwift/Sources/JWS.swift
@@ -71,7 +71,7 @@ public struct JWS {
             }
             throw JOSESwiftError.signingFailed(description: error.localizedDescription)
         }
-        
+
     }
 
     /// Constructs a JWS object from a given compact serialization string.
@@ -201,7 +201,7 @@ public struct JWS {
             return false
         }
     }
-    
+
 }
 
 extension JWS: CompactSerializable {


### PR DESCRIPTION
When a private key is protected with biometric authentication (TouchID, FaceID), it should be possible to distinguish if the signing itself fails or e.g. the authentication was canceled.
