### PR TITLE
Add dependency checker

### DIFF
--- a/.dependency_check_false_positives.xml
+++ b/.dependency_check_false_positives.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ fastlane/test_output
 
 # Sonarqube
 .scannerwork
+/dependency-check-report.json
+/dependency-check-report.html

--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,3 @@
 brew 'swiftlint'
 brew 'sonar-scanner'
+brew 'dependency-check'

--- a/Dangerfile
+++ b/Dangerfile
@@ -24,3 +24,31 @@ not_declared_trivial = !(github.pr_labels.include? "trivial")
 if has_changes && no_changelog_entry && not_declared_trivial
   message("Any non-trivial changes to code should be reflected in the changelog. Please consider adding a note in the _Unreleased_ section of the [CHANGELOG.md](https://github.com/airsidemobile/JOSESwift/blob/master/CHANGELOG.md).")
 end
+
+# ------------------------------------------------------------------------------
+# Dependency check
+# ------------------------------------------------------------------------------
+
+dependency_report_file = "./dependency-check-report.json"
+if File.exist?(dependency_report_file)
+  require "json"
+
+  file = File.read(dependency_report_file)
+  json = JSON.parse(file)
+
+  vulnerable_dependency_exists = false
+  vulnerable_dependencies = "## Vulnerable dependencies\n"
+
+  json['dependencies'].each do |dependency|
+    if dependency.key?('vulnerabilities')
+      vulnerable_dependency_exists = true
+      vulnerable_dependencies = vulnerable_dependencies + "- #{dependency['fileName']}\n"
+    end
+  end
+
+  if vulnerable_dependency_exists
+    fail(vulnerable_dependencies)
+  else
+    message("No vulnerable dependencies.")
+  end
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -130,6 +130,10 @@ lane :sonarqube do |options|
     next
   end
 
+  # Check dependencies
+
+  sh "dependency-check --enableExperimental --project . --out . -s . --format HTML --format JSON', log: false"
+
   # Convert Xcode coverage report to Sonarqube generic format
   sq_coverage_report = "#{TEST_OUTPUT}/sonarqube-coverage.xml"
   Dir.chdir("..") do

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,3 +11,5 @@ sonar.workspace=JOSESwift.xcworkspace
 sonar.scheme=JOSESwift
 sonar.sources=JOSESwift/Sources
 sonar.tests=Tests
+
+sonar.dependencyCheck.htmlReportPath=./dependency-check-report.html


### PR DESCRIPTION
I figured we didn't add the dependency checker here. I already had a brief discussion with @daniel-mohemian because GitHub's vulnerability check is already quite good but I think it doesn't support CocoaPods. I will check and also if everything works. Daniel reported that Travis CI is somehow broke. Maybe I can fix this in this PR. 