### PR TITLE
Prepare 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ so they can be moved to a respective version upon release.
 
 Add your changes here.
 
+## [2.0.0] - 2019-11-20
+
+- Fixes copyright update in prepare lane ([(#191)](https://github.com/airsidemobile/JOSESwift/pull/191)) via [@daniel-mohemian](https://github.com/daniel-mohemian)
+- Updates travis build environment ([(#190)](https://github.com/airsidemobile/JOSESwift/pull/190)) via [@daniel-mohemian](https://github.com/daniel-mohemian)
+- Adds support for RSA PSS and RS384 signatures ([(#188)](https://github.com/airsidemobile/JOSESwift/pull/188)) via [@JohanObrink](https://github.com/JohanObrink)
+- Removes twitter handle from readme again ([(#187)](https://github.com/airsidemobile/JOSESwift/pull/187)) via [@carol-mohemian](https://github.com/carol-mohemian)
+- Removes .swift-version file ([(#185)](https://github.com/airsidemobile/JOSESwift/pull/185)) via [@carol-mohemian](https://github.com/carol-mohemian)
+- Adds Ivans twitter handle ([(#184)](https://github.com/airsidemobile/JOSESwift/pull/184)) via [@carol-mohemian](https://github.com/carol-mohemian)
+- Updates fastlane ([(#182)](https://github.com/airsidemobile/JOSESwift/pull/182)) via [@daniel-mohemian](https://github.com/daniel-mohemian)
+- Adds missing license headers and automate their yearly updates ([(#179)](https://github.com/airsidemobile/JOSESwift/pull/179)) via [@daniel-mohemian](https://github.com/daniel-mohemian)
+- Extends JOSESwift Errors with localAuthentication ([(#173)](https://github.com/airsidemobile/JOSESwift/pull/173)) via [@Niklas01](https://github.com/Niklas01)
+- Bumps swift version in podspec and version file ([(#167)](https://github.com/airsidemobile/JOSESwift/pull/167)) via [@daniel-mohemian](https://github.com/daniel-mohemian)
+- Bumps fastlane to resolve mini_magic dependency warning ([(#164)](https://github.com/airsidemobile/JOSESwift/pull/164)) via [@daniel-mohemian](https://github.com/daniel-mohemian)
+- Adds security policy ([(#159)](https://github.com/airsidemobile/JOSESwift/pull/159)) via [@daniel-mohemian](https://github.com/daniel-mohemian)
+- Adds simple Sonarqube setup ([(#158)](https://github.com/airsidemobile/JOSESwift/pull/158)) via [@daniel-mohemian](https://github.com/daniel-mohemian)
+
 ## [1.8.1] - 2019-06-27
 
 - Adds tests for conversion from ASN.1 encoded EC signatures to raw EC signatures ([#160](https://github.com/airsidemobile/JOSESwift/pull/160)) via [@mschwaig](https://github.com/mschwaig)

--- a/JOSESwift.podspec
+++ b/JOSESwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "JOSESwift"
-  s.version           = "1.8.1"
+  s.version           = "2.0.0"
   s.license           = "Apache License, Version 2.0"
   s.summary           = "JOSE framework for Swift"
   s.authors           = { "Daniel Egger" => "daniel.egger@airsidemobile.com", "Carol Capek" => "carol.capek@airsidemobile.com", "Christoph Gigi Fuchs" => "christoph.fuchs@airsidemobile.com" }

--- a/JOSESwift/Support/Info.plist
+++ b/JOSESwift/Support/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.1</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ If you are missing a specific feature, algorithm, or serialization, feel free to
 	<tr><td><code>HS384</code></td><td></td>                   <td><code>RSA-OAEP</code></td><td>:white_check_mark:</td>     <td><code>A192CBC-HS384</code></td><td></td>                   <td><code>EC</code></td><td>:white_check_mark:</td></tr>
 	<tr><td><code>HS512</code></td><td></td>                   <td><code>RSA-OAEP-256</code></td><td>:white_check_mark:</td> <td><code>A256CBC-HS512</code></td><td>:white_check_mark:</td> <td><code>oct</code></td><td>:white_check_mark:</td></tr>
 	<tr><td><code>RS256</code></td><td>:white_check_mark:</td> <td><code>A128KW</code></td><td></td>                         <td><code>A128GCM</code></td><td></td>                         <th rowspan="14"></th><th rowspan="14"></th></tr>
-	<tr><td><code>RS384</code></td><td></td>                   <td><code>A192KW</code></td><td></td>                         <td><code>A192GCM</code></td><td></td>
+	<tr><td><code>RS384</code></td><td>:white_check_mark:</td> <td><code>A192KW</code></td><td></td>                         <td><code>A192GCM</code></td><td></td>
 	<tr><td><code>RS512</code></td><td>:white_check_mark:</td> <td><code>A256KW</code></td><td></td>                         <td><code>A256GCM</code></td><td></td>
 	<tr><td><code>ES256</code></td><td>:white_check_mark:</td> <td><code>dir</code></td><td>:white_check_mark:</td>          <th rowspan="11"></th><th rowspan="11"></th></tr>
 	<tr><td><code>ES384</code></td><td>:white_check_mark:</td> <td><code>ECDH-ES</code></td><td></td></tr>
 	<tr><td><code>ES512</code></td><td>:white_check_mark:</td> <td><code>ECDH-ES+A128KW</code></td><td></td></tr>
-	<tr><td><code>PS256</code></td><td></td>                   <td><code>ECDH-ES+A192KW</code></td><td></td></tr>
-	<tr><td><code>PS384</code></td><td></td>                   <td><code>ECDH-ES+A256KW</code></td><td></td></tr>
-	<tr><td><code>PS512</code></td><td></td>                   <td><code>A128GCMKW</code></td><td></td></tr>
+	<tr><td><code>PS256</code></td><td>:white_check_mark:</td> <td><code>ECDH-ES+A192KW</code></td><td></td></tr>
+	<tr><td><code>PS384</code></td><td>:white_check_mark:</td> <td><code>ECDH-ES+A256KW</code></td><td></td></tr>
+	<tr><td><code>PS512</code></td><td>:white_check_mark:</td> <td><code>A128GCMKW</code></td><td></td></tr>
 	<tr><th rowspan="5"></th><th rowspan="5"></th>             <td><code>A192GCMKW</code></td><td></td></tr>
 	<tr>                                                       <td><code>A256GCMKW</code></td><td></td></tr>
 	<tr>                                                       <td><code>PBES2-HS256+A128KW</code></td><td></td></tr>

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.1</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
The reason for the major bump is that we are now targeting the Swift 5.0 compiler.