### PR TITLE
Fine tune API changes

### DIFF
--- a/JOSESwift/Sources/Algorithms.swift
+++ b/JOSESwift/Sources/Algorithms.swift
@@ -104,3 +104,10 @@ public enum CompressionAlgorithm: String {
     case DEFLATE = "DEF"
     case NONE = "NONE"
 }
+
+// MARK: - Deprecated API
+
+@available(*, deprecated, message: "Use `KeyManagementAlgorithm` instead")
+public typealias AsymmetricKeyAlgorithm = KeyManagementAlgorithm
+@available(*, deprecated, message: "Use `ContentEncryptionAlgorithm` instead")
+public typealias SymmetricKeyAlgorithm = ContentEncryptionAlgorithm

--- a/JOSESwift/Sources/Algorithms.swift
+++ b/JOSESwift/Sources/Algorithms.swift
@@ -109,5 +109,6 @@ public enum CompressionAlgorithm: String {
 
 @available(*, deprecated, message: "Use `KeyManagementAlgorithm` instead")
 public typealias AsymmetricKeyAlgorithm = KeyManagementAlgorithm
+
 @available(*, deprecated, message: "Use `ContentEncryptionAlgorithm` instead")
 public typealias SymmetricKeyAlgorithm = ContentEncryptionAlgorithm

--- a/JOSESwift/Sources/Decrypter.swift
+++ b/JOSESwift/Sources/Decrypter.swift
@@ -92,12 +92,12 @@ extension Decrypter {
 
 extension Decrypter {
     @available(*, deprecated, message: "Use `init?(keyManagementAlgorithm:contentEncryptionAlgorithm:decryptionKey:)` instead")
-    public init?<KeyType>(keyDecryptionAlgorithm: KeyManagementAlgorithm, decryptionKey key: KeyType, contentDecryptionAlgorithm: ContentEncryptionAlgorithm) {
+    public init?<KeyType>(keyDecryptionAlgorithm: AsymmetricKeyAlgorithm, decryptionKey key: KeyType, contentDecryptionAlgorithm: SymmetricKeyAlgorithm) {
         self.init(keyManagementAlgorithm: keyDecryptionAlgorithm, contentEncryptionAlgorithm: contentDecryptionAlgorithm, decryptionKey: key)
     }
 
     @available(*, deprecated, message: "Use `init?(keyManagementAlgorithm:contentEncryptionAlgorithm:decryptionKey:)` instead")
-    public init?<KeyType>(keyDecryptionAlgorithm: KeyManagementAlgorithm, keyDecryptionKey kdk: KeyType, contentDecryptionAlgorithm: ContentEncryptionAlgorithm) {
+    public init?<KeyType>(keyDecryptionAlgorithm: AsymmetricKeyAlgorithm, keyDecryptionKey kdk: KeyType, contentDecryptionAlgorithm: SymmetricKeyAlgorithm) {
         self.init(keyDecryptionAlgorithm: keyDecryptionAlgorithm, decryptionKey: kdk, contentDecryptionAlgorithm: contentDecryptionAlgorithm)
     }
 }

--- a/JOSESwift/Sources/Decrypter.swift
+++ b/JOSESwift/Sources/Decrypter.swift
@@ -57,11 +57,11 @@ public struct Decrypter {
     }
 
     internal func decrypt(_ context: DecryptionContext) throws -> Data {
-        guard let alg = context.protectedHeader.algorithm, alg == keyManagementAlgorithm else {
+        guard let alg = context.protectedHeader.keyManagementAlgorithm, alg == keyManagementAlgorithm else {
             throw JWEError.keyManagementAlgorithmMismatch
         }
 
-        guard let enc = context.protectedHeader.encryptionAlgorithm, enc == contentEncryptionAlgorithm else {
+        guard let enc = context.protectedHeader.contentEncryptionAlgorithm, enc == contentEncryptionAlgorithm else {
             throw JWEError.contentEncryptionAlgorithmMismatch
         }
 
@@ -90,6 +90,8 @@ extension Decrypter {
     }
 }
 
+// MARK: - Deprecated API
+
 extension Decrypter {
     @available(*, deprecated, message: "Use `init?(keyManagementAlgorithm:contentEncryptionAlgorithm:decryptionKey:)` instead")
     public init?<KeyType>(keyDecryptionAlgorithm: AsymmetricKeyAlgorithm, decryptionKey key: KeyType, contentDecryptionAlgorithm: SymmetricKeyAlgorithm) {
@@ -100,4 +102,19 @@ extension Decrypter {
     public init?<KeyType>(keyDecryptionAlgorithm: AsymmetricKeyAlgorithm, keyDecryptionKey kdk: KeyType, contentDecryptionAlgorithm: SymmetricKeyAlgorithm) {
         self.init(keyDecryptionAlgorithm: keyDecryptionAlgorithm, decryptionKey: kdk, contentDecryptionAlgorithm: contentDecryptionAlgorithm)
     }
+}
+
+public struct DecryptionContext {
+    let header: JWEHeader
+    let encryptedKey: Data
+    let initializationVector: Data
+    let ciphertext: Data
+    let authenticationTag: Data
+}
+
+ public struct SymmetricDecryptionContext {
+    let ciphertext: Data
+    let initializationVector: Data
+    let additionalAuthenticatedData: Data
+    let authenticationTag: Data
 }

--- a/JOSESwift/Sources/Decrypter.swift
+++ b/JOSESwift/Sources/Decrypter.swift
@@ -104,6 +104,7 @@ extension Decrypter {
     }
 }
 
+@available(*, deprecated, message: "This type will be removed with the next major release.")
 public struct DecryptionContext {
     let header: JWEHeader
     let encryptedKey: Data
@@ -112,7 +113,8 @@ public struct DecryptionContext {
     let authenticationTag: Data
 }
 
- public struct SymmetricDecryptionContext {
+@available(*, deprecated, message: "This type will be removed with the next major release.")
+public struct SymmetricDecryptionContext {
     let ciphertext: Data
     let initializationVector: Data
     let additionalAuthenticatedData: Data

--- a/JOSESwift/Sources/Encrypter.swift
+++ b/JOSESwift/Sources/Encrypter.swift
@@ -23,7 +23,8 @@
 
 import Foundation
 
-public struct Encrypter {
+// Todo [#214]: Move generic type to initializer in next major release.
+public struct Encrypter<KeyType> {
     private let keyManagementMode: EncryptionKeyManagementMode
     private let keyManagementAlgorithm: KeyManagementAlgorithm
     private let contentEncryptionAlgorithm: ContentEncryptionAlgorithm
@@ -39,7 +40,7 @@ public struct Encrypter {
     ///       encrypted.
     ///     - For _direct encryption_ it is the secret symmetric key (`Data`) shared between the sender and the
     ///       recipient.
-    public init?<KeyType>(
+    public init?(
         keyManagementAlgorithm: KeyManagementAlgorithm,
         contentEncryptionAlgorithm: ContentEncryptionAlgorithm,
         encryptionKey: KeyType
@@ -88,14 +89,16 @@ extension Encrypter {
     }
 }
 
+// MARK: - Deprecated API
+
 extension Encrypter {
     @available(*, deprecated, message: "Use `init?(keyManagementAlgorithm:contentEncryptionAlgorithm:encryptionKey:)` instead")
-    public init?<KeyType>(keyEncryptionAlgorithm: KeyManagementAlgorithm, encryptionKey: KeyType, contentEncyptionAlgorithm: ContentEncryptionAlgorithm) {
+    public init?(keyEncryptionAlgorithm: AsymmetricKeyAlgorithm, encryptionKey: KeyType, contentEncyptionAlgorithm: SymmetricKeyAlgorithm) {
         self.init(keyManagementAlgorithm: keyEncryptionAlgorithm, contentEncryptionAlgorithm: contentEncyptionAlgorithm, encryptionKey: encryptionKey)
     }
 
     @available(*, deprecated, message: "Use `init?(keyEncryptionAlgorithm:encryptionKey:contentEncyptionAlgorithm:)` instead")
-    public init?<KeyType>(keyEncryptionAlgorithm: KeyManagementAlgorithm, keyEncryptionKey kek: KeyType, contentEncyptionAlgorithm: ContentEncryptionAlgorithm) {
+    public init?(keyEncryptionAlgorithm: AsymmetricKeyAlgorithm, keyEncryptionKey kek: KeyType, contentEncyptionAlgorithm: SymmetricKeyAlgorithm) {
         self.init(keyEncryptionAlgorithm: keyEncryptionAlgorithm, encryptionKey: kek, contentEncyptionAlgorithm: contentEncyptionAlgorithm)
     }
 }

--- a/JOSESwift/Sources/Encrypter.swift
+++ b/JOSESwift/Sources/Encrypter.swift
@@ -57,11 +57,11 @@ public struct Encrypter<KeyType> {
     }
 
     func encrypt(header: JWEHeader, payload: Payload) throws -> EncryptionContext {
-        guard let alg = header.algorithm, alg == keyManagementAlgorithm else {
+        guard let alg = header.keyManagementAlgorithm, alg == keyManagementAlgorithm else {
             throw JWEError.keyManagementAlgorithmMismatch
         }
 
-        guard let enc = header.encryptionAlgorithm, enc == contentEncryptionAlgorithm else {
+        guard let enc = header.contentEncryptionAlgorithm, enc == contentEncryptionAlgorithm else {
             throw JWEError.contentEncryptionAlgorithmMismatch
         }
 
@@ -93,12 +93,25 @@ extension Encrypter {
 
 extension Encrypter {
     @available(*, deprecated, message: "Use `init?(keyManagementAlgorithm:contentEncryptionAlgorithm:encryptionKey:)` instead")
-    public init?(keyEncryptionAlgorithm: AsymmetricKeyAlgorithm, encryptionKey: KeyType, contentEncyptionAlgorithm: SymmetricKeyAlgorithm) {
-        self.init(keyManagementAlgorithm: keyEncryptionAlgorithm, contentEncryptionAlgorithm: contentEncyptionAlgorithm, encryptionKey: encryptionKey)
+    public init?(keyEncryptionAlgorithm: AsymmetricKeyAlgorithm, encryptionKey key: KeyType, contentEncyptionAlgorithm: SymmetricKeyAlgorithm) {
+        self.init(keyManagementAlgorithm: keyEncryptionAlgorithm, contentEncryptionAlgorithm: contentEncyptionAlgorithm, encryptionKey: key)
     }
 
-    @available(*, deprecated, message: "Use `init?(keyEncryptionAlgorithm:encryptionKey:contentEncyptionAlgorithm:)` instead")
+    @available(*, deprecated, message: "Use `init?(keyManagementAlgorithm:contentEncryptionAlgorithm:encryptionKey:)` instead")
     public init?(keyEncryptionAlgorithm: AsymmetricKeyAlgorithm, keyEncryptionKey kek: KeyType, contentEncyptionAlgorithm: SymmetricKeyAlgorithm) {
         self.init(keyEncryptionAlgorithm: keyEncryptionAlgorithm, encryptionKey: kek, contentEncyptionAlgorithm: contentEncyptionAlgorithm)
     }
+}
+
+public struct EncryptionContext {
+    let encryptedKey: Data
+    let ciphertext: Data
+    let authenticationTag: Data
+    let initializationVector: Data
+}
+
+public struct SymmetricEncryptionContext {
+    let ciphertext: Data
+    let authenticationTag: Data
+    let initializationVector: Data
 }

--- a/JOSESwift/Sources/Encrypter.swift
+++ b/JOSESwift/Sources/Encrypter.swift
@@ -103,6 +103,7 @@ extension Encrypter {
     }
 }
 
+@available(*, deprecated, message: "This type will be removed with the next major release.")
 public struct EncryptionContext {
     let encryptedKey: Data
     let ciphertext: Data
@@ -110,6 +111,7 @@ public struct EncryptionContext {
     let initializationVector: Data
 }
 
+@available(*, deprecated, message: "This type will be removed with the next major release.")
 public struct SymmetricEncryptionContext {
     let ciphertext: Data
     let authenticationTag: Data

--- a/JOSESwift/Sources/JWE.swift
+++ b/JOSESwift/Sources/JWE.swift
@@ -70,10 +70,10 @@ public struct JWE {
     ///   - payload: A fully initialized `Payload`.
     ///   - encrypter: The `Encrypter` used to encrypt the JWE from the header and payload.
     /// - Throws: `JOSESwiftError` if any error occurs while encrypting.
-    public init(header: JWEHeader, payload: Payload, encrypter: Encrypter) throws {
+    public init<KeyType>(header: JWEHeader, payload: Payload, encrypter: Encrypter<KeyType>) throws {
         self.header = header
 
-        var encryptionContext: Encrypter.EncryptionContext
+        var encryptionContext: Encrypter<KeyType>.EncryptionContext
         do {
             encryptionContext = try encrypter.encrypt(header: header, payload: payload.compressed(using: header.compressionAlgorithm))
         } catch JOSESwiftError.compressionFailed {

--- a/JOSESwift/Sources/JWE.swift
+++ b/JOSESwift/Sources/JWE.swift
@@ -188,8 +188,8 @@ public struct JWE {
         )
 
         guard
-            decrypter.keyManagementAlgorithm == header.algorithm,
-            decrypter.contentEncryptionAlgorithm == header.encryptionAlgorithm
+            decrypter.keyManagementAlgorithm == header.keyManagementAlgorithm,
+            decrypter.contentEncryptionAlgorithm == header.contentEncryptionAlgorithm
         else {
             throw JOSESwiftError.decryptingFailed(description: "JWE header algorithms do not match encrypter algorithms.")
         }

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -64,10 +64,13 @@ public struct JWEHeader: JOSEHeader {
     }
 
     /// Initializes a `JWEHeader` with the specified algorithm and signing algorithm.
-    public init(algorithm: KeyManagementAlgorithm, encryptionAlgorithm: ContentEncryptionAlgorithm) {
+    public init(
+        keyManagementAlgorithm: KeyManagementAlgorithm,
+        contentEncryptionAlgorithm: ContentEncryptionAlgorithm
+    ) {
         let parameters = [
-            "alg": algorithm.rawValue,
-            "enc": encryptionAlgorithm.rawValue
+            "alg": keyManagementAlgorithm.rawValue,
+            "enc": contentEncryptionAlgorithm.rawValue
         ]
 
         // Forcing the try is ok here, since [String: String] can be converted to JSON.
@@ -89,7 +92,7 @@ public struct JWEHeader: JOSEHeader {
 // Header parameters that are specific to a JWE Header.
 public extension JWEHeader {
     /// The algorithm used to encrypt or determine the value of the Content Encryption Key.
-    var algorithm: KeyManagementAlgorithm? {
+    var keyManagementAlgorithm: KeyManagementAlgorithm? {
         // Forced cast is ok here since we checked both that "alg" exists
         // and holds a `String` value in `init(parameters:)`.
         // swiftlint:disable:next force_cast
@@ -98,7 +101,7 @@ public extension JWEHeader {
 
     /// The encryption algorithm used to perform authenticated encryption of the plaintext
     /// to produce the ciphertext and the Authentication Tag.
-    var encryptionAlgorithm: ContentEncryptionAlgorithm? {
+    var contentEncryptionAlgorithm: ContentEncryptionAlgorithm? {
         // Forced cast is ok here since we checked both that "enc" exists
         // and holds a `String` value in `init(parameters:)`.
         // swiftlint:disable:next force_cast
@@ -236,5 +239,33 @@ extension JWEHeader: CommonHeaderParameterSpace {
         get {
             return parameters["crit"] as? [String]
         }
+    }
+}
+
+// MARK: - Deprecated API
+
+public extension JWEHeader {
+    /// The algorithm used to encrypt or determine the value of the Content Encryption Key.
+    @available(*, deprecated, message: "Use `JWEHeader.keyManagementAlgorithm` instead")
+    var algorithm: AsymmetricKeyAlgorithm? {
+        // Forced cast is ok here since we checked both that "alg" exists
+        // and holds a `String` value in `init(parameters:)`.
+        // swiftlint:disable:next force_cast
+        return AsymmetricKeyAlgorithm(rawValue: parameters["alg"] as! String)
+    }
+
+    /// The encryption algorithm used to perform authenticated encryption of the plaintext
+    /// to produce the ciphertext and the Authentication Tag.
+    @available(*, deprecated, message: "Use `JWEHeader.contentEncryptionAlgorithm` instead")
+    var encryptionAlgorithm: SymmetricKeyAlgorithm? {
+        // Forced cast is ok here since we checked both that "enc" exists
+        // and holds a `String` value in `init(parameters:)`.
+        // swiftlint:disable:next force_cast
+        return SymmetricKeyAlgorithm(rawValue: parameters["enc"] as! String)
+    }
+
+    @available(*, deprecated, message: "Use `init(keyManagementAlgorithm:contentEncryptionAlgorithm` instead")
+    init(algorithm: AsymmetricKeyAlgorithm, encryptionAlgorithm: SymmetricKeyAlgorithm) {
+        self.init(keyManagementAlgorithm: algorithm, contentEncryptionAlgorithm: encryptionAlgorithm)
     }
 }

--- a/Tests/AESCBCContentEncryptionTests.swift
+++ b/Tests/AESCBCContentEncryptionTests.swift
@@ -167,7 +167,7 @@ class AESCBCContentEncryptionTests: XCTestCase {
 
     func testEncrypterHeaderPayloadInterfaceEncryptsData() throws {
         let plaintext = "Live long and prosper.".data(using: .ascii)!
-        let header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A128CBCHS256)
+        let header = JWEHeader(keyManagementAlgorithm: .RSA1_5, contentEncryptionAlgorithm: .A128CBCHS256)
 
         let cek = Data([UInt8]([
             4, 211, 31, 197, 84, 157, 252, 254, 11, 100, 157, 250, 63, 170, 106,

--- a/Tests/JWEAESKeyWrapTests.swift
+++ b/Tests/JWEAESKeyWrapTests.swift
@@ -30,7 +30,7 @@ class JWEAESKeyWrapTests: XCTestCase {
     func testRoundtrip() throws {
         let symmetricKey = Data(base64URLEncoded: "GawgguFyGrWKav7AX4VKUg")!
 
-        let header = JWEHeader(algorithm: .A128KW, encryptionAlgorithm: .A128CBCHS256)
+        let header = JWEHeader(keyManagementAlgorithm: .A128KW, contentEncryptionAlgorithm: .A128CBCHS256)
         let payload = Payload("Live long and prosper.".data(using: .ascii)!)
         let encrypter = Encrypter(
             keyManagementAlgorithm: .A128KW,
@@ -55,7 +55,7 @@ class JWEAESKeyWrapTests: XCTestCase {
         let symmetricKey = Data(base64URLEncoded: "GawgguFyGrWKav7AX4VKUg")!
         let wrongSymmetricKey = Data(base64URLEncoded: "WRONGuFyGrWKav7AX4VKUg")!
 
-        let header = JWEHeader(algorithm: .A128KW, encryptionAlgorithm: .A128CBCHS256)
+        let header = JWEHeader(keyManagementAlgorithm: .A128KW, contentEncryptionAlgorithm: .A128CBCHS256)
         let payload = Payload("Live long and prosper.".data(using: .ascii)!)
         let encrypter = Encrypter(
             keyManagementAlgorithm: .A128KW,

--- a/Tests/JWECompressionTests.swift
+++ b/Tests/JWECompressionTests.swift
@@ -56,7 +56,7 @@ class JWECompressionTests: RSACryptoTestCase {
     func testRoundtripDirectEncryption() {
         let symmetricKey = try! SecureRandom.generate(count: ContentEncryptionAlgorithm.A256CBCHS512.keyLength)
 
-        var header = JWEHeader(algorithm: .direct, encryptionAlgorithm: .A256CBCHS512)
+        var header = JWEHeader(keyManagementAlgorithm: .direct, contentEncryptionAlgorithm: .A256CBCHS512)
         header.zip = "DEF"
 
         let payload = Payload(data)
@@ -71,7 +71,7 @@ class JWECompressionTests: RSACryptoTestCase {
     }
 
     func testRoundtripKeyEncryption() {
-        var header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512)
+        var header = JWEHeader(keyManagementAlgorithm: .RSA1_5, contentEncryptionAlgorithm: .A256CBCHS512)
         header.zip = "DEF"
 
         let payload = Payload(data)
@@ -100,7 +100,7 @@ class JWECompressionTests: RSACryptoTestCase {
     func testEncryptWithNotSupportedZipHeaderValue() {
         let symmetricKey = try! SecureRandom.generate(count: ContentEncryptionAlgorithm.A256CBCHS512.keyLength)
 
-        var header = JWEHeader(algorithm: .direct, encryptionAlgorithm: .A256CBCHS512)
+        var header = JWEHeader(keyManagementAlgorithm: .direct, contentEncryptionAlgorithm: .A256CBCHS512)
         header.zip = "GZIP"
 
         let payload = Payload(data)

--- a/Tests/JWEHeaderTests.swift
+++ b/Tests/JWEHeaderTests.swift
@@ -115,42 +115,42 @@ class JWEHeaderTests: XCTestCase {
     }
 
     func testInitWithAlgAndEncRSA1() {
-        let header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512)
+        let header = JWEHeader(keyManagementAlgorithm: .RSA1_5, contentEncryptionAlgorithm: .A256CBCHS512)
 
         XCTAssertEqual(header.data().count, try! JSONSerialization.data(withJSONObject: parameterDictRSA, options: []).count)
         XCTAssertEqual(header.parameters["alg"] as? String, KeyManagementAlgorithm.RSA1_5.rawValue)
         XCTAssertEqual(header.parameters["enc"] as? String, ContentEncryptionAlgorithm.A256CBCHS512.rawValue)
 
-        XCTAssertNotNil(header.algorithm)
-        XCTAssertNotNil(header.encryptionAlgorithm)
-        XCTAssertEqual(header.algorithm!, .RSA1_5)
-        XCTAssertEqual(header.encryptionAlgorithm!, .A256CBCHS512)
+        XCTAssertNotNil(header.keyManagementAlgorithm)
+        XCTAssertNotNil(header.contentEncryptionAlgorithm)
+        XCTAssertEqual(header.keyManagementAlgorithm!, .RSA1_5)
+        XCTAssertEqual(header.contentEncryptionAlgorithm!, .A256CBCHS512)
     }
 
     func testInitWithAlgAndEncRSAOAEP() {
-        let header = JWEHeader(algorithm: .RSAOAEP, encryptionAlgorithm: .A256CBCHS512)
+        let header = JWEHeader(keyManagementAlgorithm: .RSAOAEP, contentEncryptionAlgorithm: .A256CBCHS512)
 
         XCTAssertEqual(header.data().count, try! JSONSerialization.data(withJSONObject: parameterDictRSAOAEP, options: []).count)
         XCTAssertEqual(header.parameters["alg"] as? String, KeyManagementAlgorithm.RSAOAEP.rawValue)
         XCTAssertEqual(header.parameters["enc"] as? String, ContentEncryptionAlgorithm.A256CBCHS512.rawValue)
 
-        XCTAssertNotNil(header.algorithm)
-        XCTAssertNotNil(header.encryptionAlgorithm)
-        XCTAssertEqual(header.algorithm!, .RSAOAEP)
-        XCTAssertEqual(header.encryptionAlgorithm!, .A256CBCHS512)
+        XCTAssertNotNil(header.keyManagementAlgorithm)
+        XCTAssertNotNil(header.contentEncryptionAlgorithm)
+        XCTAssertEqual(header.keyManagementAlgorithm!, .RSAOAEP)
+        XCTAssertEqual(header.contentEncryptionAlgorithm!, .A256CBCHS512)
     }
 
     func testInitWithAlgAndEncRSAOAEP256() {
-        let header = JWEHeader(algorithm: .RSAOAEP256, encryptionAlgorithm: .A256CBCHS512)
+        let header = JWEHeader(keyManagementAlgorithm: .RSAOAEP256, contentEncryptionAlgorithm: .A256CBCHS512)
 
         XCTAssertEqual(header.data().count, try! JSONSerialization.data(withJSONObject: parameterDictRSAOAEP256, options: []).count)
         XCTAssertEqual(header.parameters["alg"] as? String, KeyManagementAlgorithm.RSAOAEP256.rawValue)
         XCTAssertEqual(header.parameters["enc"] as? String, ContentEncryptionAlgorithm.A256CBCHS512.rawValue)
 
-        XCTAssertNotNil(header.algorithm)
-        XCTAssertNotNil(header.encryptionAlgorithm)
-        XCTAssertEqual(header.algorithm!, .RSAOAEP256)
-        XCTAssertEqual(header.encryptionAlgorithm!, .A256CBCHS512)
+        XCTAssertNotNil(header.keyManagementAlgorithm)
+        XCTAssertNotNil(header.contentEncryptionAlgorithm)
+        XCTAssertEqual(header.keyManagementAlgorithm!, .RSAOAEP256)
+        XCTAssertEqual(header.contentEncryptionAlgorithm!, .A256CBCHS512)
     }
 
     func testInitWithMissingRequiredEncParameter() {
@@ -218,7 +218,7 @@ class JWEHeaderTests: XCTestCase {
         let crit = ["crit1", "crit2"]
         let zip = "DEF"
 
-        var header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512)
+        var header = JWEHeader(keyManagementAlgorithm: .RSA1_5, contentEncryptionAlgorithm: .A256CBCHS512)
         header.jku = jku
         header.jwk = jwk
         header.kid = kid
@@ -272,5 +272,14 @@ class JWEHeaderTests: XCTestCase {
 
         header.zip = "GZIP"
         XCTAssertEqual(header.compressionAlgorithm, nil)
+    }
+
+    @available(*, deprecated)
+    func testDeprecatedAPI() {
+        let header1 = JWEHeader(algorithm: .A128KW, encryptionAlgorithm: .A128CBCHS256)
+        let header2 = JWEHeader(keyManagementAlgorithm: .A128KW, contentEncryptionAlgorithm: .A128CBCHS256)
+
+        XCTAssertEqual(header1.algorithm, header1.keyManagementAlgorithm)
+        XCTAssertEqual(header2.encryptionAlgorithm, header1.contentEncryptionAlgorithm)
     }
 }

--- a/Tests/JWERSATests.swift
+++ b/Tests/JWERSATests.swift
@@ -112,7 +112,7 @@ class JWERSATests: RSACryptoTestCase {
             return
         }
 
-        let header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A256CBCHS512)
+        let header = JWEHeader(keyManagementAlgorithm: .RSA1_5, contentEncryptionAlgorithm: .A256CBCHS512)
         let payload = Payload(message.data(using: .utf8)!)
         let encrypter = Encrypter(keyManagementAlgorithm: .RSAOAEP, contentEncryptionAlgorithm: .A256CBCHS512, encryptionKey: publicKeyAlice2048)!
 
@@ -125,7 +125,7 @@ class JWERSATests: RSACryptoTestCase {
             return
         }
 
-        let header = JWEHeader(algorithm: .RSA1_5, encryptionAlgorithm: .A128CBCHS256)
+        let header = JWEHeader(keyManagementAlgorithm: .RSA1_5, contentEncryptionAlgorithm: .A128CBCHS256)
         let payload = Payload(message.data(using: .utf8)!)
         let encrypter = Encrypter(keyManagementAlgorithm: .RSA1_5, contentEncryptionAlgorithm: .A256CBCHS512, encryptionKey: publicKeyAlice2048)!
 


### PR DESCRIPTION
Provides deprecated API fallbacks for breaking API changes. This should allow us to release the key wrap implementation as non breaking change as part of the 2.x.x major release.