### PR TITLE
Add JWK thumbprint computation

### DIFF
--- a/JOSESwift.xcodeproj/project.pbxproj
+++ b/JOSESwift.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		5FB76E6F2080BEC6B63939D6 /* ECSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB76AF2833DDD77D56D6D3F /* ECSigner.swift */; };
 		5FB76E7A42B44E4F4416CB7F /* JWKECKeysTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB7688B4092265A9A950E9E /* JWKECKeysTests.swift */; };
 		5FB76E7BEF001684139C9E14 /* ECCryptoTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB76BD4F46045BF2B182483 /* ECCryptoTestCase.swift */; };
+		612B0C94248E1C83009F1929 /* Thumbprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612B0C93248E1C83009F1929 /* Thumbprint.swift */; };
 		6501503723FBDB42000D7D0B /* AESKeyWrapKeyManagementModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6501503623FBDB42000D7D0B /* AESKeyWrapKeyManagementModeTests.swift */; };
 		6506D9E920F4CA2000F34DD8 /* SymmetricKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6506D9E820F4CA2000F34DD8 /* SymmetricKeyTests.swift */; };
 		65125A321FBF85FA007CF3AE /* JWSDeserializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65125A311FBF85FA007CF3AE /* JWSDeserializationTests.swift */; };
@@ -157,6 +158,7 @@
 		5FB76E4A3A52AAC72B1F33F0 /* SecKeyECPrivateKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecKeyECPrivateKey.swift; sourceTree = "<group>"; };
 		5FB76E8AD96EA19B669A5E1D /* ECPublicKeyToSecKeyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ECPublicKeyToSecKeyTests.swift; sourceTree = "<group>"; };
 		5FB76EBD36093E9EC475BC2B /* ECKeyCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ECKeyCodable.swift; sourceTree = "<group>"; };
+		612B0C93248E1C83009F1929 /* Thumbprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thumbprint.swift; sourceTree = "<group>"; };
 		6501503623FBDB42000D7D0B /* AESKeyWrapKeyManagementModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AESKeyWrapKeyManagementModeTests.swift; sourceTree = "<group>"; };
 		6506D9E820F4CA2000F34DD8 /* SymmetricKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymmetricKeyTests.swift; sourceTree = "<group>"; };
 		65125A311FBF85FA007CF3AE /* JWSDeserializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWSDeserializationTests.swift; sourceTree = "<group>"; };
@@ -577,6 +579,7 @@
 				5FB763EED5A790CCC29F8771 /* DataECPublicKey.swift */,
 				5FB7604267B94DC5091D7105 /* DataECPrivateKey.swift */,
 				5FB76E4A3A52AAC72B1F33F0 /* SecKeyECPrivateKey.swift */,
+				612B0C93248E1C83009F1929 /* Thumbprint.swift */,
 			);
 			path = CryptoImplementation;
 			sourceTree = "<group>";
@@ -812,6 +815,7 @@
 				6533552E1F8FB61000A660C6 /* JWE.swift in Sources */,
 				C85B1EF4204D82860026BDCB /* Signer.swift in Sources */,
 				8A30B8F822118FD0001834E3 /* DeflateWrapper.swift in Sources */,
+				612B0C94248E1C83009F1929 /* Thumbprint.swift in Sources */,
 				65D8E8EA20F4AF880059506A /* SymmetricKeyCodable.swift in Sources */,
 				C85B1EF6204D82970026BDCB /* RSASigner.swift in Sources */,
 				65344C3E20F4CC9000FCBBA1 /* DataSymmetricKey.swift in Sources */,

--- a/JOSESwift/Sources/Algorithms.swift
+++ b/JOSESwift/Sources/Algorithms.swift
@@ -96,6 +96,13 @@ public enum HMACAlgorithm: String {
     }
 }
 
+/// An algorithm for Thumbprint calculation.
+///
+/// - SHA256
+public enum ThumbprintAlgorithm: String {
+    case SHA256
+}
+
 /// An algorithm for compressing the plain text before encryption.
 /// List of [supported compression algorithms](https://www.iana.org/assignments/jose/jose.xhtml#web-encryption-compression-algorithms)
 ///

--- a/JOSESwift/Sources/Algorithms.swift
+++ b/JOSESwift/Sources/Algorithms.swift
@@ -96,10 +96,10 @@ public enum HMACAlgorithm: String {
     }
 }
 
-/// An algorithm for Thumbprint calculation.
+/// An algorithm for JWK Thumbprint calculation.
 ///
 /// - SHA256
-public enum ThumbprintAlgorithm: String {
+public enum JWKThumbprintAlgorithm: String {
     case SHA256
 }
 

--- a/JOSESwift/Sources/CryptoImplementation/Thumbprint.swift
+++ b/JOSESwift/Sources/CryptoImplementation/Thumbprint.swift
@@ -1,0 +1,68 @@
+//
+//  SHA256.swift
+//  JOSESwift
+//
+//  Created by Thomas Torp on 08.06.20.
+//
+//  ---------------------------------------------------------------------------
+//  Copyright 2019 Airside Mobile Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ---------------------------------------------------------------------------
+//
+
+import Foundation
+import CommonCrypto
+
+enum ThumbprintError: Error {
+    case inputMustBeGreaterThanZero
+}
+
+fileprivate extension ThumbprintAlgorithm {
+    var outputLenght: Int {
+        switch self {
+        case .SHA256:
+            return Int(CC_SHA256_DIGEST_LENGTH)
+        }
+    }
+
+    func calculate(input: UnsafeRawBufferPointer, output: UnsafeMutablePointer<UInt8>) {
+        switch self {
+        case .SHA256:
+            CC_SHA256(input.baseAddress, CC_LONG(input.count), output)
+        }
+    }
+}
+
+internal struct Thumbprint {
+    /// Calculates a hash of an input with a specific hash algorithm.
+    ///
+    /// - Parameters:
+    ///   - input: The input to calculate a hash for.
+    ///   - algorithm: The algorithm used to calculate the HMAC.
+    /// - Returns: The calculated hash in base64URLEncoding.
+    static func calculate(from input: Data, algorithm: ThumbprintAlgorithm) throws -> String {
+        guard input.count > 0 else {
+            throw ThumbprintError.inputMustBeGreaterThanZero
+        }
+
+        let hashBytes = UnsafeMutablePointer<UInt8>.allocate(capacity: algorithm.outputLenght)
+        defer { hashBytes.deallocate() }
+
+        input.withUnsafeBytes { (buffer) -> Void in
+            algorithm.calculate(input: buffer, output: hashBytes)
+        }
+
+        return Data(bytes: hashBytes, count: algorithm.outputLenght).base64URLEncodedString()
+    }
+}

--- a/JOSESwift/Sources/CryptoImplementation/Thumbprint.swift
+++ b/JOSESwift/Sources/CryptoImplementation/Thumbprint.swift
@@ -28,7 +28,7 @@ enum ThumbprintError: Error {
     case inputMustBeGreaterThanZero
 }
 
-fileprivate extension ThumbprintAlgorithm {
+fileprivate extension JWKThumbprintAlgorithm {
     var outputLenght: Int {
         switch self {
         case .SHA256:
@@ -49,9 +49,9 @@ internal struct Thumbprint {
     ///
     /// - Parameters:
     ///   - input: The input to calculate a hash for.
-    ///   - algorithm: The algorithm used to calculate the HMAC.
+    ///   - algorithm: The algorithm used to calculate the hash.
     /// - Returns: The calculated hash in base64URLEncoding.
-    static func calculate(from input: Data, algorithm: ThumbprintAlgorithm) throws -> String {
+    static func calculate(from input: Data, algorithm: JWKThumbprintAlgorithm) throws -> String {
         guard input.count > 0 else {
             throw ThumbprintError.inputMustBeGreaterThanZero
         }
@@ -59,7 +59,7 @@ internal struct Thumbprint {
         let hashBytes = UnsafeMutablePointer<UInt8>.allocate(capacity: algorithm.outputLenght)
         defer { hashBytes.deallocate() }
 
-        input.withUnsafeBytes { (buffer) -> Void in
+        input.withUnsafeBytes { buffer in
             algorithm.calculate(input: buffer, output: hashBytes)
         }
 

--- a/JOSESwift/Sources/DataExtensions.swift
+++ b/JOSESwift/Sources/DataExtensions.swift
@@ -22,7 +22,6 @@
 //
 
 import Foundation
-import CommonCrypto
 
 extension Data {
     /// Creates a new data buffer from a base64url encoded string.

--- a/JOSESwift/Sources/DataExtensions.swift
+++ b/JOSESwift/Sources/DataExtensions.swift
@@ -121,16 +121,3 @@ extension Data: DataConvertible {
         return self
     }
 }
-
-extension Data {
-    var sha256: String {
-        let hashBytes = UnsafeMutablePointer<UInt8>.allocate(capacity: Int(CC_SHA256_DIGEST_LENGTH))
-        defer { hashBytes.deallocate() }
-
-        withUnsafeBytes { (buffer) -> Void in
-            CC_SHA256(buffer.baseAddress, CC_LONG(buffer.count), hashBytes)
-        }
-
-        return Data(bytes: hashBytes, count: Int(CC_SHA256_DIGEST_LENGTH)).base64URLEncodedString()
-    }
-}

--- a/JOSESwift/Sources/DataExtensions.swift
+++ b/JOSESwift/Sources/DataExtensions.swift
@@ -22,6 +22,7 @@
 //
 
 import Foundation
+import CommonCrypto
 
 extension Data {
     /// Creates a new data buffer from a base64url encoded string.
@@ -118,5 +119,18 @@ extension Data: DataConvertible {
 
     public func data() -> Data {
         return self
+    }
+}
+
+extension Data {
+    var sha256: String {
+        let hashBytes = UnsafeMutablePointer<UInt8>.allocate(capacity: Int(CC_SHA256_DIGEST_LENGTH))
+        defer { hashBytes.deallocate() }
+
+        withUnsafeBytes { (buffer) -> Void in
+            CC_SHA256(buffer.baseAddress, CC_LONG(buffer.count), hashBytes)
+        }
+
+        return Data(bytes: hashBytes, count: Int(CC_SHA256_DIGEST_LENGTH)).base64URLEncodedString()
     }
 }

--- a/JOSESwift/Sources/ECKeys.swift
+++ b/JOSESwift/Sources/ECKeys.swift
@@ -99,7 +99,7 @@ public struct ECPublicKey: JWK {
     public let parameters: [String: String]
 
     /// The EC public key required parameters
-    public var requiredParamters: [String: String] {
+    public var requiredParameters: [String: String] {
         [
             JWKParameter.keyType.rawValue: self.keyType.rawValue,
             ECParameter.curve.rawValue: self.crv.rawValue,
@@ -218,7 +218,7 @@ public struct ECPrivateKey: JWK {
     public let parameters: [String: String]
 
     /// The EC private key required parameters
-    public var requiredParamters: [String: String] {
+    public var requiredParameters: [String: String] {
         [
             JWKParameter.keyType.rawValue: self.keyType.rawValue,
             ECParameter.curve.rawValue: self.crv.rawValue,

--- a/JOSESwift/Sources/ECKeys.swift
+++ b/JOSESwift/Sources/ECKeys.swift
@@ -199,7 +199,7 @@ public struct ECPublicKey: JWK {
     }
 
     @available(iOS 11.0, *)
-    public func withKeyIdFromThumbprint(algorithm: ThumbprintAlgorithm = .SHA256) throws -> Self {
+    public func withThumbprintAsKeyId(algorithm: JWKThumbprintAlgorithm = .SHA256) throws -> Self {
         let keyId = try thumbprint(algorithm: algorithm)
         return .init(crv: crv, x: x, y: y, additionalParameters: [
             JWKParameter.keyIdentifier.rawValue: keyId
@@ -331,7 +331,7 @@ public struct ECPrivateKey: JWK {
     }
 
     @available(iOS 11.0, *)
-    public func withKeyIdFromThumbprint(algorithm: ThumbprintAlgorithm = .SHA256) throws -> Self {
+    public func withThumbprintAsKeyId(algorithm: JWKThumbprintAlgorithm = .SHA256) throws -> Self {
         let keyId = try thumbprint(algorithm: algorithm)
         return try .init(crv: crv.rawValue, x: x, y: y, privateKey: privateKey, additionalParameters: [
             JWKParameter.keyIdentifier.rawValue: keyId

--- a/JOSESwift/Sources/ECKeys.swift
+++ b/JOSESwift/Sources/ECKeys.swift
@@ -199,8 +199,8 @@ public struct ECPublicKey: JWK {
     }
 
     @available(iOS 11.0, *)
-    public func withKeyIdFromThumbprint() throws -> Self {
-        let keyId = try thumbprint()
+    public func withKeyIdFromThumbprint(algorithm: ThumbprintAlgorithm = .SHA256) throws -> Self {
+        let keyId = try thumbprint(algorithm: algorithm)
         return .init(crv: crv, x: x, y: y, additionalParameters: [
             JWKParameter.keyIdentifier.rawValue: keyId
         ])
@@ -331,8 +331,8 @@ public struct ECPrivateKey: JWK {
     }
 
     @available(iOS 11.0, *)
-    public func withKeyIdFromThumbprint() throws -> Self {
-        let keyId = try thumbprint()
+    public func withKeyIdFromThumbprint(algorithm: ThumbprintAlgorithm = .SHA256) throws -> Self {
+        let keyId = try thumbprint(algorithm: algorithm)
         return try .init(crv: crv.rawValue, x: x, y: y, privateKey: privateKey, additionalParameters: [
             JWKParameter.keyIdentifier.rawValue: keyId
         ])

--- a/JOSESwift/Sources/ECKeys.swift
+++ b/JOSESwift/Sources/ECKeys.swift
@@ -98,6 +98,16 @@ public struct ECPublicKey: JWK {
     /// The JWK parameters.
     public let parameters: [String: String]
 
+    /// The EC public key required parameters
+    public var requiredParamters: [String: String] {
+        [
+            JWKParameter.keyType.rawValue: self.keyType.rawValue,
+            ECParameter.curve.rawValue: self.crv.rawValue,
+            ECParameter.x.rawValue: self.x,
+            ECParameter.y.rawValue: self.y
+        ]
+    }
+
     /// The curve value for the EC public key.
     public let crv: ECCurveType
 
@@ -187,6 +197,14 @@ public struct ECPublicKey: JWK {
 
         return try T.representing(ecPublicKeyComponents: (self.crv.rawValue, x, y))
     }
+
+    @available(iOS 11.0, *)
+    public func withKeyIdFromThumbprint() throws -> Self {
+        let keyId = try thumbprint()
+        return .init(crv: crv, x: x, y: y, additionalParameters: [
+            JWKParameter.keyIdentifier.rawValue: keyId
+        ])
+    }
 }
 
 // MARK: Private Key
@@ -198,6 +216,16 @@ public struct ECPrivateKey: JWK {
 
     /// The JWK parameters.
     public let parameters: [String: String]
+
+    /// The EC private key required parameters
+    public var requiredParamters: [String: String] {
+        [
+            JWKParameter.keyType.rawValue: self.keyType.rawValue,
+            ECParameter.curve.rawValue: self.crv.rawValue,
+            ECParameter.x.rawValue: self.x,
+            ECParameter.y.rawValue: self.y
+        ]
+    }
 
     /// The curve value for the EC public key.
     public let crv: ECCurveType
@@ -300,6 +328,14 @@ public struct ECPrivateKey: JWK {
         }
 
         return try T.representing(ecPrivateKeyComponents: (self.crv.rawValue, x, y, privateKey))
+    }
+
+    @available(iOS 11.0, *)
+    public func withKeyIdFromThumbprint() throws -> Self {
+        let keyId = try thumbprint()
+        return try .init(crv: crv.rawValue, x: x, y: y, privateKey: privateKey, additionalParameters: [
+            JWKParameter.keyIdentifier.rawValue: keyId
+        ])
     }
 }
 

--- a/JOSESwift/Sources/JOSESwiftError.swift
+++ b/JOSESwift/Sources/JOSESwiftError.swift
@@ -60,4 +60,7 @@ public enum JOSESwiftError: Error {
     case compressionAlgorithmNotSupported
     case rawDataMustBeGreaterThanZero
     case compressedDataMustBeGreaterThanZero
+
+    // Thumprint computation
+    case thumbprintSerialization
 }

--- a/JOSESwift/Sources/JWK.swift
+++ b/JOSESwift/Sources/JWK.swift
@@ -92,18 +92,18 @@ public protocol JWK: Codable {
     /// - Returns: The thumbprint from the required members of the JWK key.
     /// - Throws: A `JOSESwiftError` indicating any errors.
     @available(iOS 11.0, *)
-    func thumbprint() throws -> String
+    func thumbprint(algorithm: ThumbprintAlgorithm) throws -> String
 
     @available(iOS 11.0, *)
-    func withKeyIdFromThumbprint() throws -> Self
+    func withKeyIdFromThumbprint(algorithm: ThumbprintAlgorithm) throws -> Self
 }
 
 extension JWK {
     @available(iOS 11.0, *)
-    public func thumbprint() throws -> String {
+    public func thumbprint(algorithm: ThumbprintAlgorithm = .SHA256) throws -> String {
         guard let json = try? JSONSerialization.data(withJSONObject: requiredParameters, options: .sortedKeys) else {
             throw JOSESwiftError.thumbprintSerialization
         }
-        return json.sha256
+        return try Thumbprint.calculate(from: json, algorithm: algorithm)
     }
 }

--- a/JOSESwift/Sources/JWK.swift
+++ b/JOSESwift/Sources/JWK.swift
@@ -57,7 +57,7 @@ public protocol JWK: Codable {
     /// [RFC 7518, Section 6](https://tools.ietf.org/html/rfc7518#section-6) for possible parameters.
     var parameters: [String: String] { get }
 
-    var requiredParamters: [String: String] { get }
+    var requiredParameters: [String: String] { get }
 
     /// Accesses the specified parameter.
     /// The parameters of the JWK representing the properties of the key(s), including the value(s).
@@ -101,7 +101,7 @@ public protocol JWK: Codable {
 extension JWK {
     @available(iOS 11.0, *)
     public func thumbprint() throws -> String {
-        guard let json = try? JSONSerialization.data(withJSONObject: requiredParamters, options: .sortedKeys) else {
+        guard let json = try? JSONSerialization.data(withJSONObject: requiredParameters, options: .sortedKeys) else {
             throw JOSESwiftError.thumbprintSerialization
         }
         return json.sha256

--- a/JOSESwift/Sources/JWK.swift
+++ b/JOSESwift/Sources/JWK.swift
@@ -86,21 +86,23 @@ public protocol JWK: Codable {
     ///            `nil` if the encoding failed.
     func jsonData() -> Data?
 
-    /// Generate the thumbprint based on hash function SHA256
+    /// Generate the key's thumbprint.
     ///  See [RFC-7638, Section 3.2](https://tools.ietf.org/html/rfc7638#section-3.2)
     ///
-    /// - Returns: The thumbprint from the required members of the JWK key.
+    /// - Parameters:
+    ///   - algorithm: The hash algorithm to use for the thumbprint calculation.
+    /// - Returns: he base64url encoded thumbprint of the required members of the JWK key.
     /// - Throws: A `JOSESwiftError` indicating any errors.
     @available(iOS 11.0, *)
-    func thumbprint(algorithm: ThumbprintAlgorithm) throws -> String
+    func thumbprint(algorithm: JWKThumbprintAlgorithm) throws -> String
 
     @available(iOS 11.0, *)
-    func withKeyIdFromThumbprint(algorithm: ThumbprintAlgorithm) throws -> Self
+    func withThumbprintAsKeyId(algorithm: JWKThumbprintAlgorithm) throws -> Self
 }
 
 extension JWK {
     @available(iOS 11.0, *)
-    public func thumbprint(algorithm: ThumbprintAlgorithm = .SHA256) throws -> String {
+    public func thumbprint(algorithm: JWKThumbprintAlgorithm = .SHA256) throws -> String {
         guard let json = try? JSONSerialization.data(withJSONObject: requiredParameters, options: .sortedKeys) else {
             throw JOSESwiftError.thumbprintSerialization
         }

--- a/JOSESwift/Sources/JWK.swift
+++ b/JOSESwift/Sources/JWK.swift
@@ -57,6 +57,8 @@ public protocol JWK: Codable {
     /// [RFC 7518, Section 6](https://tools.ietf.org/html/rfc7518#section-6) for possible parameters.
     var parameters: [String: String] { get }
 
+    var requiredParamters: [String: String] { get }
+
     /// Accesses the specified parameter.
     /// The parameters of the JWK representing the properties of the key(s), including the value(s).
     /// Check [RFC 7517, Section 4](https://tools.ietf.org/html/rfc7517#section-4) and
@@ -83,4 +85,25 @@ public protocol JWK: Codable {
     /// - Returns: The JSON representation of the JWK as `Data` or
     ///            `nil` if the encoding failed.
     func jsonData() -> Data?
+
+    /// Generate the thumbprint based on hash function SHA256
+    ///  See [RFC-7638, Section 3.2](https://tools.ietf.org/html/rfc7638#section-3.2)
+    ///
+    /// - Returns: The thumbprint from the required members of the JWK key.
+    /// - Throws: A `JOSESwiftError` indicating any errors.
+    @available(iOS 11.0, *)
+    func thumbprint() throws -> String
+
+    @available(iOS 11.0, *)
+    func withKeyIdFromThumbprint() throws -> Self
+}
+
+extension JWK {
+    @available(iOS 11.0, *)
+    public func thumbprint() throws -> String {
+        guard let json = try? JSONSerialization.data(withJSONObject: requiredParamters, options: .sortedKeys) else {
+            throw JOSESwiftError.thumbprintSerialization
+        }
+        return json.sha256
+    }
 }

--- a/JOSESwift/Sources/JWK.swift
+++ b/JOSESwift/Sources/JWK.swift
@@ -96,6 +96,13 @@ public protocol JWK: Codable {
     @available(iOS 11.0, *)
     func thumbprint(algorithm: JWKThumbprintAlgorithm) throws -> String
 
+    /// Use the thumbprint as the keyId.
+    ///  See [RFC-7638, Section 3.2](https://tools.ietf.org/html/rfc7638#section-3.2)
+    ///
+    /// - Parameters:
+    ///   - algorithm: The hash algorithm to use for the thumbprint calculation.
+    /// - Returns: The JWK key with the thumbprint as keyId.
+    /// - Throws: A `JOSESwiftError` indicating any errors.
     @available(iOS 11.0, *)
     func withThumbprintAsKeyId(algorithm: JWKThumbprintAlgorithm) throws -> Self
 }
@@ -107,5 +114,10 @@ extension JWK {
             throw JOSESwiftError.thumbprintSerialization
         }
         return try Thumbprint.calculate(from: json, algorithm: algorithm)
+    }
+
+    @available(iOS 11.0, *)
+    func withThumbprintAsKeyId(algorithm: JWKThumbprintAlgorithm = .SHA256) throws -> Self {
+        return try withThumbprintAsKeyId(algorithm: algorithm)
     }
 }

--- a/JOSESwift/Sources/RSAKeys.swift
+++ b/JOSESwift/Sources/RSAKeys.swift
@@ -96,6 +96,15 @@ public struct RSAPublicKey: JWK {
     /// The JWK parameters.
     public let parameters: [String: String]
 
+    /// The RSA required parameters
+    public var requiredParamters: [String: String] {
+        [
+            JWKParameter.keyType.rawValue: self.keyType.rawValue,
+            RSAParameter.modulus.rawValue: self.modulus,
+            RSAParameter.exponent.rawValue: self.exponent
+        ]
+    }
+
     /// The modulus value for the RSA public key.
     public let modulus: String
 
@@ -174,6 +183,14 @@ public struct RSAPublicKey: JWK {
 
         return try T.representing(rsaPublicKeyComponents: (modulusData, exponentData))
     }
+
+    @available(iOS 11.0, *)
+    public func withKeyIdFromThumbprint() throws -> Self {
+        let keyId = try thumbprint()
+        return .init(modulus: modulus, exponent: exponent, additionalParameters: [
+            JWKParameter.keyIdentifier.rawValue: keyId
+        ])
+    }
 }
 
 // MARK: Private Key
@@ -185,6 +202,15 @@ public struct RSAPrivateKey: JWK {
 
     /// The JWK parameters.
     public let parameters: [String: String]
+
+    /// The RSA required parameters
+    public var requiredParamters: [String: String] {
+        [
+            JWKParameter.keyType.rawValue: self.keyType.rawValue,
+            RSAParameter.modulus.rawValue: self.modulus,
+            RSAParameter.exponent.rawValue: self.exponent
+        ]
+    }
 
     /// The modulus value for the RSA private key.
     public let modulus: String
@@ -272,6 +298,14 @@ public struct RSAPrivateKey: JWK {
         }
 
         return try T.representing(rsaPrivateKeyComponents: (modulusData, exponentData, privateExponentData))
+    }
+
+    @available(iOS 11.0, *)
+    public func withKeyIdFromThumbprint() throws -> Self {
+        let keyId = try thumbprint()
+        return .init(modulus: modulus, exponent: exponent, privateExponent: privateExponent, additionalParameters: [
+            JWKParameter.keyIdentifier.rawValue: keyId
+        ])
     }
 }
 

--- a/JOSESwift/Sources/RSAKeys.swift
+++ b/JOSESwift/Sources/RSAKeys.swift
@@ -97,7 +97,7 @@ public struct RSAPublicKey: JWK {
     public let parameters: [String: String]
 
     /// The RSA required parameters
-    public var requiredParamters: [String: String] {
+    public var requiredParameters: [String: String] {
         [
             JWKParameter.keyType.rawValue: self.keyType.rawValue,
             RSAParameter.modulus.rawValue: self.modulus,
@@ -204,7 +204,7 @@ public struct RSAPrivateKey: JWK {
     public let parameters: [String: String]
 
     /// The RSA required parameters
-    public var requiredParamters: [String: String] {
+    public var requiredParameters: [String: String] {
         [
             JWKParameter.keyType.rawValue: self.keyType.rawValue,
             RSAParameter.modulus.rawValue: self.modulus,

--- a/JOSESwift/Sources/RSAKeys.swift
+++ b/JOSESwift/Sources/RSAKeys.swift
@@ -185,8 +185,8 @@ public struct RSAPublicKey: JWK {
     }
 
     @available(iOS 11.0, *)
-    public func withKeyIdFromThumbprint() throws -> Self {
-        let keyId = try thumbprint()
+    public func withKeyIdFromThumbprint(algorithm: ThumbprintAlgorithm = .SHA256) throws -> Self {
+        let keyId = try thumbprint(algorithm: algorithm)
         return .init(modulus: modulus, exponent: exponent, additionalParameters: [
             JWKParameter.keyIdentifier.rawValue: keyId
         ])
@@ -301,8 +301,8 @@ public struct RSAPrivateKey: JWK {
     }
 
     @available(iOS 11.0, *)
-    public func withKeyIdFromThumbprint() throws -> Self {
-        let keyId = try thumbprint()
+    public func withKeyIdFromThumbprint(algorithm: ThumbprintAlgorithm = .SHA256) throws -> Self {
+        let keyId = try thumbprint(algorithm: algorithm)
         return .init(modulus: modulus, exponent: exponent, privateExponent: privateExponent, additionalParameters: [
             JWKParameter.keyIdentifier.rawValue: keyId
         ])

--- a/JOSESwift/Sources/RSAKeys.swift
+++ b/JOSESwift/Sources/RSAKeys.swift
@@ -185,7 +185,7 @@ public struct RSAPublicKey: JWK {
     }
 
     @available(iOS 11.0, *)
-    public func withKeyIdFromThumbprint(algorithm: ThumbprintAlgorithm = .SHA256) throws -> Self {
+    public func withThumbprintAsKeyId(algorithm: JWKThumbprintAlgorithm = .SHA256) throws -> Self {
         let keyId = try thumbprint(algorithm: algorithm)
         return .init(modulus: modulus, exponent: exponent, additionalParameters: [
             JWKParameter.keyIdentifier.rawValue: keyId
@@ -301,7 +301,7 @@ public struct RSAPrivateKey: JWK {
     }
 
     @available(iOS 11.0, *)
-    public func withKeyIdFromThumbprint(algorithm: ThumbprintAlgorithm = .SHA256) throws -> Self {
+    public func withThumbprintAsKeyId(algorithm: JWKThumbprintAlgorithm = .SHA256) throws -> Self {
         let keyId = try thumbprint(algorithm: algorithm)
         return .init(modulus: modulus, exponent: exponent, privateExponent: privateExponent, additionalParameters: [
             JWKParameter.keyIdentifier.rawValue: keyId

--- a/JOSESwift/Sources/SymmetricKeys.swift
+++ b/JOSESwift/Sources/SymmetricKeys.swift
@@ -128,8 +128,8 @@ public struct SymmetricKey: JWK {
     }
 
     @available(iOS 11.0, *)
-    public func withKeyIdFromThumbprint() throws -> Self {
-        let keyId = try thumbprint()
+    public func withKeyIdFromThumbprint(algorithm: ThumbprintAlgorithm = .SHA256) throws -> Self {
+        let keyId = try thumbprint(algorithm: algorithm)
         return .init(key: try converted(to: Data.self), additionalParameters: [
             JWKParameter.keyIdentifier.rawValue: keyId
         ])

--- a/JOSESwift/Sources/SymmetricKeys.swift
+++ b/JOSESwift/Sources/SymmetricKeys.swift
@@ -59,6 +59,14 @@ public struct SymmetricKey: JWK {
     /// The JWK parameters.
     public let parameters: [String: String]
 
+    /// The symmetric key required parameters
+    public var requiredParamters: [String: String] {
+        [
+            JWKParameter.keyType.rawValue: self.keyType.rawValue,
+            SymmetricKeyParameter.key.rawValue: self.key
+        ]
+    }
+
     /// The symmetric key represented as
     /// base64url encoding of the octet sequence containing the key data.
     public let key: String
@@ -117,5 +125,13 @@ public struct SymmetricKey: JWK {
             throw JOSESwiftError.symmetricKeyNotBase64URLEncoded
         }
         return try T.representing(symmetricKeyComponents: (keyData))
+    }
+
+    @available(iOS 11.0, *)
+    public func withKeyIdFromThumbprint() throws -> Self {
+        let keyId = try thumbprint()
+        return .init(key: try converted(to: Data.self), additionalParameters: [
+            JWKParameter.keyIdentifier.rawValue: keyId
+        ])
     }
 }

--- a/JOSESwift/Sources/SymmetricKeys.swift
+++ b/JOSESwift/Sources/SymmetricKeys.swift
@@ -128,7 +128,7 @@ public struct SymmetricKey: JWK {
     }
 
     @available(iOS 11.0, *)
-    public func withKeyIdFromThumbprint(algorithm: ThumbprintAlgorithm = .SHA256) throws -> Self {
+    public func withThumbprintAsKeyId(algorithm: JWKThumbprintAlgorithm = .SHA256) throws -> Self {
         let keyId = try thumbprint(algorithm: algorithm)
         return .init(key: try converted(to: Data.self), additionalParameters: [
             JWKParameter.keyIdentifier.rawValue: keyId

--- a/JOSESwift/Sources/SymmetricKeys.swift
+++ b/JOSESwift/Sources/SymmetricKeys.swift
@@ -60,7 +60,7 @@ public struct SymmetricKey: JWK {
     public let parameters: [String: String]
 
     /// The symmetric key required parameters
-    public var requiredParamters: [String: String] {
+    public var requiredParameters: [String: String] {
         [
             JWKParameter.keyType.rawValue: self.keyType.rawValue,
             SymmetricKeyParameter.key.rawValue: self.key

--- a/Tests/ECCryptoTestCase.swift
+++ b/Tests/ECCryptoTestCase.swift
@@ -40,6 +40,7 @@ struct ECTestKeyData {
     let expectedXCoordinateBase64Url: String
     let expectedYCoordinate: Data
     let expectedYCoordinateBase64Url: String
+    let expectedThumbprint: String
     let privateKey: SecKey
     let privateKeyData: Data
     let publicKey: SecKey
@@ -61,6 +62,7 @@ struct ECTestKeyData {
             expectedYCoordinate: Data,
             expectedYCoordinateBase64Url: String,
             expectedCurveType: String,
+            expectedThumbprint: String,
             signatureAlgorithm: String) {
 
         self.privateKeyTag = privateKeyTag
@@ -80,6 +82,7 @@ struct ECTestKeyData {
         self.expectedYCoordinate = expectedYCoordinate
         self.expectedYCoordinateBase64Url = expectedYCoordinateBase64Url
         self.expectedCurveType = expectedCurveType
+        self.expectedThumbprint = expectedThumbprint
         self.signatureAlgorithm = signatureAlgorithm
 
         let keyData: Data = ECTestKeyData.createKeyData(
@@ -157,6 +160,7 @@ class ECCryptoTestCase: CryptoTestCase {
                 ]),
                 expectedYCoordinateBase64Url: "saNr4hM3qrojSoY4eaO1WGVna5yW_I4EqdFQ4TRl8iQ",
                 expectedCurveType: "P-256",
+                expectedThumbprint: "2i6Yjdy_beRJCkTcJbKmHT4L7LtVWdm5gYw9573NMHo",
                 signatureAlgorithm: "ES256"
         )
 
@@ -189,6 +193,7 @@ class ECCryptoTestCase: CryptoTestCase {
                 ]),
                 expectedYCoordinateBase64Url: "h3zkf9eaHcJ7Dw7SMPfKwJ2PEgHYeZ-P-vOxlBS_OsBx7RFz-yNan1e_P0hS-LgN",
                 expectedCurveType: "P-384",
+                expectedThumbprint: "1Njn97uiY347iWNFsvjS0fOATTHhdp8pDzSkb0FCYzo",
                 signatureAlgorithm: "ES384"
         )
 
@@ -230,6 +235,7 @@ class ECCryptoTestCase: CryptoTestCase {
                 expectedYCoordinateBase64Url:
                 "ASeWzvPD_vogLYkT1GkyXEpwR3V94hKVCrWGNLFvlAJ-CpgGO2XA_MnvjwoCNzV8kElKz2G7K3thxzamfJot-lYh",
                 expectedCurveType: "P-521",
+                expectedThumbprint: "UV9y65LDwmzpVq7JFYfMwsuoumxTJhjeZyZtnISsPao",
                 signatureAlgorithm: "ES512"
         )
     }

--- a/Tests/JWKECKeysTests.swift
+++ b/Tests/JWKECKeysTests.swift
@@ -174,4 +174,58 @@ class JWKECKeysTests: ECCryptoTestCase {
 
         XCTFail()
     }
+
+    @available(iOS 11.0, *)
+    func testThumbprintPublicKey() {
+        allTestData.forEach { keyData in
+            let key = ECPublicKey(
+                    crv: ECCurveType(rawValue: keyData.expectedCurveType)!,
+                    x: keyData.expectedXCoordinateBase64Url,
+                    y: keyData.expectedYCoordinateBase64Url
+            )
+
+            XCTAssertEqual(try? key.thumbprint(), keyData.expectedThumbprint)
+        }
+    }
+
+    @available(iOS 11.0, *)
+    func testThumbprintPrivateKey() {
+        allTestData.forEach { keyData in
+            let key = try! ECPrivateKey(
+                    crv: keyData.expectedCurveType,
+                    x: keyData.expectedXCoordinateBase64Url,
+                    y: keyData.expectedYCoordinateBase64Url,
+                    privateKey: keyData.expectedPrivateBase64Url
+            )
+
+            XCTAssertEqual(try? key.thumbprint(), keyData.expectedThumbprint)
+        }
+    }
+
+    @available(iOS 11.0, *)
+    func testAddPublicThumbprintToJWK() throws {
+        try allTestData.forEach { keyData in
+            let key = try ECPublicKey(
+                    crv: ECCurveType(rawValue: keyData.expectedCurveType)!,
+                    x: keyData.expectedXCoordinateBase64Url,
+                    y: keyData.expectedYCoordinateBase64Url
+            ).withKeyIdFromThumbprint()
+
+            XCTAssertEqual(key.parameters[JWKParameter.keyIdentifier.rawValue], keyData.expectedThumbprint)
+        }
+    }
+
+    @available(iOS 11.0, *)
+    func testAddPrivateThumbprintToJWK() throws {
+        try allTestData.forEach { keyData in
+            let key = try ECPrivateKey(
+                    crv: keyData.expectedCurveType,
+                    x: keyData.expectedXCoordinateBase64Url,
+                    y: keyData.expectedYCoordinateBase64Url,
+                    privateKey: keyData.expectedPrivateBase64Url
+            ).withKeyIdFromThumbprint()
+
+            XCTAssertEqual(key.parameters[JWKParameter.keyIdentifier.rawValue], keyData.expectedThumbprint)
+        }
+    }
 }

--- a/Tests/JWKECKeysTests.swift
+++ b/Tests/JWKECKeysTests.swift
@@ -209,7 +209,7 @@ class JWKECKeysTests: ECCryptoTestCase {
                     crv: ECCurveType(rawValue: keyData.expectedCurveType)!,
                     x: keyData.expectedXCoordinateBase64Url,
                     y: keyData.expectedYCoordinateBase64Url
-            ).withKeyIdFromThumbprint()
+            ).withThumbprintAsKeyId()
 
             XCTAssertEqual(key.parameters[JWKParameter.keyIdentifier.rawValue], keyData.expectedThumbprint)
         }
@@ -223,7 +223,7 @@ class JWKECKeysTests: ECCryptoTestCase {
                     x: keyData.expectedXCoordinateBase64Url,
                     y: keyData.expectedYCoordinateBase64Url,
                     privateKey: keyData.expectedPrivateBase64Url
-            ).withKeyIdFromThumbprint()
+            ).withThumbprintAsKeyId()
 
             XCTAssertEqual(key.parameters[JWKParameter.keyIdentifier.rawValue], keyData.expectedThumbprint)
         }

--- a/Tests/JWKRSAKeysTests.swift
+++ b/Tests/JWKRSAKeysTests.swift
@@ -122,4 +122,28 @@ class JWKRSAKeysTests: RSACryptoTestCase {
 
         XCTAssertEqual(jwk.parameters.count, 6)
     }
+
+    @available(iOS 11.0, *)
+    func testThumbprintPublicKey() {
+        let jwk = RSAPublicKey(modulus: "n", exponent: "e")
+        XCTAssertEqual(try? jwk.thumbprint(), "lPd1Hx7fpYY23pQVKnFvOEtk_jFe5EV8ZISUGTSGA_U")
+    }
+
+    @available(iOS 11.0, *)
+    func testThumbprintPrivateKey() {
+        let jwk = RSAPrivateKey(modulus: "A", exponent: "B", privateExponent: "C")
+        XCTAssertEqual(try? jwk.thumbprint(), "slXDutAKWp8bubkrYoqeq5EwSQDtZdooHiG4TVQUptY")
+    }
+
+    @available(iOS 11.0, *)
+    func testAddPublicThumbprintToJWK() throws {
+        let jwk = try RSAPublicKey(modulus: "n", exponent: "e").withKeyIdFromThumbprint()
+        XCTAssertEqual(jwk.parameters[JWKParameter.keyIdentifier.rawValue], "lPd1Hx7fpYY23pQVKnFvOEtk_jFe5EV8ZISUGTSGA_U")
+    }
+
+    @available(iOS 11.0, *)
+    func testAddPrivateThumbprintToJWK() throws {
+        let jwk = try RSAPrivateKey(modulus: "A", exponent: "B", privateExponent: "C").withKeyIdFromThumbprint()
+        XCTAssertEqual(jwk.parameters[JWKParameter.keyIdentifier.rawValue], "slXDutAKWp8bubkrYoqeq5EwSQDtZdooHiG4TVQUptY")
+    }
 }

--- a/Tests/JWKRSAKeysTests.swift
+++ b/Tests/JWKRSAKeysTests.swift
@@ -137,13 +137,13 @@ class JWKRSAKeysTests: RSACryptoTestCase {
 
     @available(iOS 11.0, *)
     func testAddPublicThumbprintToJWK() throws {
-        let jwk = try RSAPublicKey(modulus: "n", exponent: "e").withKeyIdFromThumbprint()
+        let jwk = try RSAPublicKey(modulus: "n", exponent: "e").withThumbprintAsKeyId()
         XCTAssertEqual(jwk.parameters[JWKParameter.keyIdentifier.rawValue], "lPd1Hx7fpYY23pQVKnFvOEtk_jFe5EV8ZISUGTSGA_U")
     }
 
     @available(iOS 11.0, *)
     func testAddPrivateThumbprintToJWK() throws {
-        let jwk = try RSAPrivateKey(modulus: "A", exponent: "B", privateExponent: "C").withKeyIdFromThumbprint()
+        let jwk = try RSAPrivateKey(modulus: "A", exponent: "B", privateExponent: "C").withThumbprintAsKeyId()
         XCTAssertEqual(jwk.parameters[JWKParameter.keyIdentifier.rawValue], "slXDutAKWp8bubkrYoqeq5EwSQDtZdooHiG4TVQUptY")
     }
 }

--- a/Tests/SymmetricKeyTests.swift
+++ b/Tests/SymmetricKeyTests.swift
@@ -146,7 +146,7 @@ class SymmetricKeyTests: XCTestCase {
         let jwk = try SymmetricKey(
             key: key,
             additionalParameters: [ "alg": ContentEncryptionAlgorithm.A256CBCHS512.rawValue ]
-        ).withKeyIdFromThumbprint()
+        ).withThumbprintAsKeyId()
 
         XCTAssertEqual(jwk.parameters[JWKParameter.keyIdentifier.rawValue], "k1JnWRfC-5zzmL72vXIuBgTLfVROXBakS4OmGcrMCoc")
     }

--- a/Tests/SymmetricKeyTests.swift
+++ b/Tests/SymmetricKeyTests.swift
@@ -123,4 +123,31 @@ class SymmetricKeyTests: XCTestCase {
         XCTAssertThrowsError(try SymmetricKey(data: json))
     }
 
+    @available(iOS 11.0, *)
+    func testThumbprintSymmetricKey() {
+        let key = Data([
+            0x19, 0xac, 0x20, 0x82, 0xe1, 0x72, 0x1a, 0xb5, 0x8a, 0x6a, 0xfe, 0xc0, 0x5f, 0x85, 0x4a, 0x52
+        ])
+
+        let jwk = SymmetricKey(
+            key: key,
+            additionalParameters: [ "alg": ContentEncryptionAlgorithm.A256CBCHS512.rawValue ]
+        )
+
+        XCTAssertEqual(try? jwk.thumbprint(), "k1JnWRfC-5zzmL72vXIuBgTLfVROXBakS4OmGcrMCoc")
+    }
+
+    @available(iOS 11.0, *)
+    func testAddThumbprintToJWK() throws {
+        let key = Data([
+            0x19, 0xac, 0x20, 0x82, 0xe1, 0x72, 0x1a, 0xb5, 0x8a, 0x6a, 0xfe, 0xc0, 0x5f, 0x85, 0x4a, 0x52
+        ])
+
+        let jwk = try SymmetricKey(
+            key: key,
+            additionalParameters: [ "alg": ContentEncryptionAlgorithm.A256CBCHS512.rawValue ]
+        ).withKeyIdFromThumbprint()
+
+        XCTAssertEqual(jwk.parameters[JWKParameter.keyIdentifier.rawValue], "k1JnWRfC-5zzmL72vXIuBgTLfVROXBakS4OmGcrMCoc")
+    }
 }


### PR DESCRIPTION
Im currently using the thumbprint computed from the required fields in the key as the keyIdentifier in my own project and wanted to see if you wanted to add it to JOSESwift.

Its based on the [RFC-7638](https://tools.ietf.org/html/rfc7638).

Hopefully it can help other people also :)

Just give me a shout out if something needs to be changed or rewritten :)