### PR TITLE
Copy parameters when updating JWT with keyId

### DIFF
--- a/JOSESwift/Sources/ECKeys.swift
+++ b/JOSESwift/Sources/ECKeys.swift
@@ -201,9 +201,9 @@ public struct ECPublicKey: JWK {
     @available(iOS 11.0, *)
     public func withThumbprintAsKeyId(algorithm: JWKThumbprintAlgorithm = .SHA256) throws -> Self {
         let keyId = try thumbprint(algorithm: algorithm)
-        return .init(crv: crv, x: x, y: y, additionalParameters: [
+        return .init(crv: crv, x: x, y: y, additionalParameters: parameters.merging([
             JWKParameter.keyIdentifier.rawValue: keyId
-        ])
+        ], uniquingKeysWith: { (_, new) in new }))
     }
 }
 
@@ -333,9 +333,9 @@ public struct ECPrivateKey: JWK {
     @available(iOS 11.0, *)
     public func withThumbprintAsKeyId(algorithm: JWKThumbprintAlgorithm = .SHA256) throws -> Self {
         let keyId = try thumbprint(algorithm: algorithm)
-        return try .init(crv: crv.rawValue, x: x, y: y, privateKey: privateKey, additionalParameters: [
+        return try .init(crv: crv.rawValue, x: x, y: y, privateKey: privateKey, additionalParameters: parameters.merging([
             JWKParameter.keyIdentifier.rawValue: keyId
-        ])
+        ], uniquingKeysWith: { (_, new) in new }))
     }
 }
 

--- a/JOSESwift/Sources/RSAKeys.swift
+++ b/JOSESwift/Sources/RSAKeys.swift
@@ -187,9 +187,9 @@ public struct RSAPublicKey: JWK {
     @available(iOS 11.0, *)
     public func withThumbprintAsKeyId(algorithm: JWKThumbprintAlgorithm = .SHA256) throws -> Self {
         let keyId = try thumbprint(algorithm: algorithm)
-        return .init(modulus: modulus, exponent: exponent, additionalParameters: [
+        return .init(modulus: modulus, exponent: exponent, additionalParameters: parameters.merging([
             JWKParameter.keyIdentifier.rawValue: keyId
-        ])
+        ], uniquingKeysWith: { (_, new) in new }))
     }
 }
 
@@ -303,9 +303,9 @@ public struct RSAPrivateKey: JWK {
     @available(iOS 11.0, *)
     public func withThumbprintAsKeyId(algorithm: JWKThumbprintAlgorithm = .SHA256) throws -> Self {
         let keyId = try thumbprint(algorithm: algorithm)
-        return .init(modulus: modulus, exponent: exponent, privateExponent: privateExponent, additionalParameters: [
+        return .init(modulus: modulus, exponent: exponent, privateExponent: privateExponent, additionalParameters: parameters.merging([
             JWKParameter.keyIdentifier.rawValue: keyId
-        ])
+        ], uniquingKeysWith: { (_, new) in new }))
     }
 }
 

--- a/JOSESwift/Sources/SymmetricKeys.swift
+++ b/JOSESwift/Sources/SymmetricKeys.swift
@@ -130,8 +130,8 @@ public struct SymmetricKey: JWK {
     @available(iOS 11.0, *)
     public func withThumbprintAsKeyId(algorithm: JWKThumbprintAlgorithm = .SHA256) throws -> Self {
         let keyId = try thumbprint(algorithm: algorithm)
-        return .init(key: try converted(to: Data.self), additionalParameters: [
+        return .init(key: try converted(to: Data.self), additionalParameters: parameters.merging([
             JWKParameter.keyIdentifier.rawValue: keyId
-        ])
+        ], uniquingKeysWith: { (_, new) in new }))
     }
 }

--- a/Tests/JWKECKeysTests.swift
+++ b/Tests/JWKECKeysTests.swift
@@ -216,6 +216,22 @@ class JWKECKeysTests: ECCryptoTestCase {
     }
 
     @available(iOS 11.0, *)
+    func testAddPublicThumbprintToJWKCopyParameters() throws {
+        let useKey = "sig"
+        try allTestData.forEach { keyData in
+            let key = try ECPublicKey(
+                    crv: ECCurveType(rawValue: keyData.expectedCurveType)!,
+                    x: keyData.expectedXCoordinateBase64Url,
+                    y: keyData.expectedYCoordinateBase64Url,
+                    additionalParameters: [JWKParameter.keyUse.rawValue: useKey]
+            ).withThumbprintAsKeyId()
+
+            XCTAssertEqual(key.parameters[JWKParameter.keyIdentifier.rawValue], keyData.expectedThumbprint)
+            XCTAssertEqual(key.parameters[JWKParameter.keyUse.rawValue], useKey)
+        }
+    }
+
+    @available(iOS 11.0, *)
     func testAddPrivateThumbprintToJWK() throws {
         try allTestData.forEach { keyData in
             let key = try ECPrivateKey(
@@ -226,6 +242,23 @@ class JWKECKeysTests: ECCryptoTestCase {
             ).withThumbprintAsKeyId()
 
             XCTAssertEqual(key.parameters[JWKParameter.keyIdentifier.rawValue], keyData.expectedThumbprint)
+        }
+    }
+
+    @available(iOS 11.0, *)
+    func testAddPrivateThumbprintToJWKCopyParameters() throws {
+        let useKey = "sig"
+        try allTestData.forEach { keyData in
+            let key = try ECPrivateKey(
+                    crv: keyData.expectedCurveType,
+                    x: keyData.expectedXCoordinateBase64Url,
+                    y: keyData.expectedYCoordinateBase64Url,
+                    privateKey: keyData.expectedPrivateBase64Url,
+                    additionalParameters: [JWKParameter.keyUse.rawValue: useKey]
+            ).withThumbprintAsKeyId()
+
+            XCTAssertEqual(key.parameters[JWKParameter.keyIdentifier.rawValue], keyData.expectedThumbprint)
+            XCTAssertEqual(key.parameters[JWKParameter.keyUse.rawValue], useKey)
         }
     }
 }

--- a/Tests/JWKRSAKeysTests.swift
+++ b/Tests/JWKRSAKeysTests.swift
@@ -142,8 +142,24 @@ class JWKRSAKeysTests: RSACryptoTestCase {
     }
 
     @available(iOS 11.0, *)
+    func testAddPublicThumbprintToJWKCopyParamters() throws {
+        let useKey = "sig"
+        let jwk = try RSAPublicKey(modulus: "n", exponent: "e", additionalParameters: [JWKParameter.keyUse.rawValue: useKey]).withThumbprintAsKeyId()
+        XCTAssertEqual(jwk.parameters[JWKParameter.keyIdentifier.rawValue], "lPd1Hx7fpYY23pQVKnFvOEtk_jFe5EV8ZISUGTSGA_U")
+        XCTAssertEqual(jwk.parameters[JWKParameter.keyUse.rawValue], useKey)
+    }
+
+    @available(iOS 11.0, *)
     func testAddPrivateThumbprintToJWK() throws {
         let jwk = try RSAPrivateKey(modulus: "A", exponent: "B", privateExponent: "C").withThumbprintAsKeyId()
         XCTAssertEqual(jwk.parameters[JWKParameter.keyIdentifier.rawValue], "slXDutAKWp8bubkrYoqeq5EwSQDtZdooHiG4TVQUptY")
+    }
+
+    @available(iOS 11.0, *)
+    func testAddPrivateThumbprintToJWKCopyParamters() throws {
+        let useKey = "sig"
+        let jwk = try RSAPrivateKey(modulus: "A", exponent: "B", privateExponent: "C", additionalParameters: [JWKParameter.keyUse.rawValue: useKey]).withThumbprintAsKeyId()
+        XCTAssertEqual(jwk.parameters[JWKParameter.keyIdentifier.rawValue], "slXDutAKWp8bubkrYoqeq5EwSQDtZdooHiG4TVQUptY")
+        XCTAssertEqual(jwk.parameters[JWKParameter.keyUse.rawValue], useKey)
     }
 }

--- a/Tests/SymmetricKeyTests.swift
+++ b/Tests/SymmetricKeyTests.swift
@@ -131,7 +131,7 @@ class SymmetricKeyTests: XCTestCase {
 
         let jwk = SymmetricKey(
             key: key,
-            additionalParameters: [ "alg": ContentEncryptionAlgorithm.A256CBCHS512.rawValue ]
+            additionalParameters: [ JWKParameter.algorithm.rawValue: ContentEncryptionAlgorithm.A256CBCHS512.rawValue ]
         )
 
         XCTAssertEqual(try? jwk.thumbprint(), "k1JnWRfC-5zzmL72vXIuBgTLfVROXBakS4OmGcrMCoc")
@@ -145,9 +145,24 @@ class SymmetricKeyTests: XCTestCase {
 
         let jwk = try SymmetricKey(
             key: key,
-            additionalParameters: [ "alg": ContentEncryptionAlgorithm.A256CBCHS512.rawValue ]
+            additionalParameters: [ JWKParameter.algorithm.rawValue: ContentEncryptionAlgorithm.A256CBCHS512.rawValue ]
         ).withThumbprintAsKeyId()
 
         XCTAssertEqual(jwk.parameters[JWKParameter.keyIdentifier.rawValue], "k1JnWRfC-5zzmL72vXIuBgTLfVROXBakS4OmGcrMCoc")
+    }
+
+    @available(iOS 11.0, *)
+    func testAddThumbprintToJWKCopyParameters() throws {
+        let key = Data([
+            0x19, 0xac, 0x20, 0x82, 0xe1, 0x72, 0x1a, 0xb5, 0x8a, 0x6a, 0xfe, 0xc0, 0x5f, 0x85, 0x4a, 0x52
+        ])
+
+        let jwk = try SymmetricKey(
+            key: key,
+            additionalParameters: [ JWKParameter.algorithm.rawValue: ContentEncryptionAlgorithm.A256CBCHS512.rawValue ]
+        ).withThumbprintAsKeyId()
+
+        XCTAssertEqual(jwk.parameters[JWKParameter.keyIdentifier.rawValue], "k1JnWRfC-5zzmL72vXIuBgTLfVROXBakS4OmGcrMCoc")
+        XCTAssertEqual(jwk.parameters[JWKParameter.algorithm.rawValue], ContentEncryptionAlgorithm.A256CBCHS512.rawValue)
     }
 }


### PR DESCRIPTION
Hi again!

I found a minor bug when using the withThumbprintAsKeyId function. I forgot to copy potensial additionalParameters 😬 
Added the fix and a couple of new tests.