### PR TITLE
Support for RSAPrivateKey init from JWK token

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/JOSESwift.xcodeproj/project.pbxproj
+++ b/JOSESwift.xcodeproj/project.pbxproj
@@ -97,6 +97,8 @@
 		8A30B8FA22118FE6001834E3 /* JWECompressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A30B8F922118FE6001834E3 /* JWECompressionTests.swift */; };
 		8A4B08B22213FF0600828536 /* Compressor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4B08B12213FF0600828536 /* Compressor.swift */; };
 		9665A24722B0F3E100EAC14A /* ECAsn1IntegerConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9665A24622B0F3E100EAC14A /* ECAsn1IntegerConversionTests.swift */; };
+		C322EB8A24E5202700678682 /* SecKeyRSAPrivateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = C322EB8924E5202700678682 /* SecKeyRSAPrivateKey.swift */; };
+		C322EB8C24E5204900678682 /* DataRSAPrivateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = C322EB8B24E5204900678682 /* DataRSAPrivateKey.swift */; };
 		C803EFE51FA77E3000B71335 /* JWSRSATests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C803EFE41FA77E3000B71335 /* JWSRSATests.swift */; };
 		C803EFE91FA7893A00B71335 /* JWSHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C803EFE81FA7893A00B71335 /* JWSHeaderTests.swift */; };
 		C803EFED1FA8849C00B71335 /* JWERSATests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C803EFEC1FA8849C00B71335 /* JWERSATests.swift */; };
@@ -226,6 +228,8 @@
 		8A30B8F922118FE6001834E3 /* JWECompressionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JWECompressionTests.swift; sourceTree = "<group>"; };
 		8A4B08B12213FF0600828536 /* Compressor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Compressor.swift; sourceTree = "<group>"; };
 		9665A24622B0F3E100EAC14A /* ECAsn1IntegerConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ECAsn1IntegerConversionTests.swift; sourceTree = "<group>"; };
+		C322EB8924E5202700678682 /* SecKeyRSAPrivateKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecKeyRSAPrivateKey.swift; sourceTree = "<group>"; };
+		C322EB8B24E5204900678682 /* DataRSAPrivateKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataRSAPrivateKey.swift; sourceTree = "<group>"; };
 		C803EFE41FA77E3000B71335 /* JWSRSATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWSRSATests.swift; sourceTree = "<group>"; };
 		C803EFE81FA7893A00B71335 /* JWSHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWSHeaderTests.swift; sourceTree = "<group>"; };
 		C803EFEC1FA8849C00B71335 /* JWERSATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWERSATests.swift; sourceTree = "<group>"; };
@@ -568,7 +572,9 @@
 			isa = PBXGroup;
 			children = (
 				6582614C2029E98A00B594ED /* DataRSAPublicKey.swift */,
+				C322EB8B24E5204900678682 /* DataRSAPrivateKey.swift */,
 				65344C3D20F4CC9000FCBBA1 /* DataSymmetricKey.swift */,
+				C322EB8924E5202700678682 /* SecKeyRSAPrivateKey.swift */,
 				6546FB0E2029DD10002E421F /* SecKeyRSAPublicKey.swift */,
 				C85012E21FE04E0C00EC49FA /* SecureRandom.swift */,
 				C81DD9271FD7096100026024 /* HMAC.swift */,
@@ -784,6 +790,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C322EB8A24E5202700678682 /* SecKeyRSAPrivateKey.swift in Sources */,
 				65617FCD1F90FB7600D8C743 /* RSAKeyEncryptionMode.swift in Sources */,
 				65617FCB1F90F8C700D8C743 /* Encrypter.swift in Sources */,
 				65E733CC1FEBE8320009EAC6 /* JWKExtensions.swift in Sources */,
@@ -822,6 +829,7 @@
 				65D868111F7CEBA200769BBF /* Verifier.swift in Sources */,
 				C86B876D203D857B00208387 /* JOSESwiftError.swift in Sources */,
 				65A77E941F7285A900A66DDE /* JOSEHeader.swift in Sources */,
+				C322EB8C24E5204900678682 /* DataRSAPrivateKey.swift in Sources */,
 				6533552A1F8F6B6800A660C6 /* JWEHeader.swift in Sources */,
 				65353F5D1F750A6A003E099B /* DataExtensions.swift in Sources */,
 				65E733D11FEBF7960009EAC6 /* JWKParameters.swift in Sources */,

--- a/JOSESwift/Sources/CryptoImplementation/DataRSAPrivateKey.swift
+++ b/JOSESwift/Sources/CryptoImplementation/DataRSAPrivateKey.swift
@@ -26,43 +26,88 @@ import Foundation
 
 extension Data: ExpressibleAsRSAPrivateKeyComponents {
     public static func representing(rsaPrivateKeyComponents components: RSAPrivateKeyComponents) throws -> Data {
-        var modulusBytes = [UInt8](components.modulus)
+        let modulusBytes = [UInt8](components.modulus).prefixingZeroByte()
         let exponentBytes = [UInt8](components.exponent)
-        let privateExponentBytes = [UInt8](components.privateExponent)
+        let privateExponentBytes = [UInt8](components.privateExponent).prefixingZeroByte()
 
-        // Ensure the modulus is prefixed with 0x00.
-        if let prefix = modulusBytes.first, prefix != 0x00 {
-            modulusBytes.insert(0x00, at: 0)
-        }
+        let prime1Bytes = [UInt8](components.prime1).prefixingZeroByte()
+        let prime2Bytes = [UInt8](components.prime2).prefixingZeroByte()
+        let exponent1Bytes = [UInt8](components.exponent1).prefixingZeroByte()
+        let exponent2Bytes = [UInt8](components.exponent2).prefixingZeroByte()
+        let coefficientBytes = [UInt8](components.coefficient).prefixingZeroByte()
+
+        let zeroBytes = [UInt8]([0x00])
+        let leadingZeroEncoded = zeroBytes.encode(as: .integer)
 
         let modulusEncoded = modulusBytes.encode(as: .integer)
         let exponentEncoded = exponentBytes.encode(as: .integer)
         let privateExponentEncoded = privateExponentBytes.encode(as: .integer)
 
-        let sequenceEncoded = (modulusEncoded + exponentEncoded + privateExponentEncoded).encode(as: .sequence)
+        let prime1Encoded = prime1Bytes.encode(as: .integer)
+        let prime2Encoded = prime2Bytes.encode(as: .integer)
+        let exponent1Encoded = exponent1Bytes.encode(as: .integer)
+        let exponent2Encoded = exponent2Bytes.encode(as: .integer)
+        let coefficientEncoded = coefficientBytes.encode(as: .integer)
+
+        let sequenceEncoded = (leadingZeroEncoded + modulusEncoded + exponentEncoded + privateExponentEncoded + prime1Encoded + prime2Encoded + exponent1Encoded + exponent2Encoded + coefficientEncoded).encode(as: .sequence)
 
         return Data(sequenceEncoded)
     }
 
-    // TODO: this will be wrong
     public func rsaPrivateKeyComponents() throws -> RSAPrivateKeyComponents {
         let publicKeyBytes = [UInt8](self)
 
         let sequence = try publicKeyBytes.read(.sequence)
-        var modulus = try sequence.read(.integer)
-        let exponent = try sequence.skip(.integer).read(.integer)
-        let privateExponent = try sequence.skip(.integer).skip(.integer).read(.integer)
+        let modulus = try sequence.getNthInteger(1)
+        let exponent = try sequence.getNthInteger(2)
+        let privateExponent = try sequence.getNthInteger(3)
 
-        // Remove potential leading zero byte.
-        // See https://tools.ietf.org/html/rfc7518#section-6.3.1.1.
-        if modulus.first == 0x00 {
-            modulus = Array(modulus.dropFirst())
-        }
+        let prime1 = try sequence.getNthInteger(4)
+        let prime2 = try sequence.getNthInteger(5)
+        let exponent1 = try sequence.getNthInteger(6)
+        let exponent2 = try sequence.getNthInteger(7)
+        let coefficient = try sequence.getNthInteger(8)
 
         return (
             Data(modulus),
             Data(exponent),
-            Data(privateExponent)
+            Data(privateExponent),
+            Data(prime1),
+            Data(prime2),
+            Data(exponent1),
+            Data(exponent2),
+            Data(coefficient)
         )
     }
 }
+
+internal extension Array where Element == UInt8 {
+    func getNthInteger(_ n: Int) throws -> [UInt8] {
+        var seq = self
+        for _ in 0 ..< n {
+            seq = try seq.skip(.integer)
+        }
+        var val = try seq.read(.integer)
+
+        if val.first == 0x00 {
+            val = Array(val.dropFirst())
+        }
+        return val
+    }
+}
+
+extension Array where Element == UInt8 {
+    func prefixingZeroByte() -> [UInt8] {
+        if let prefix = self.first, prefix.isMsbSet() {
+            return [0x00] + self
+        }
+        return self
+    }
+}
+
+extension UInt8 {
+    func isMsbSet() -> Bool {
+        self & (1 << 7) != 0
+    }
+}
+

--- a/JOSESwift/Sources/CryptoImplementation/DataRSAPrivateKey.swift
+++ b/JOSESwift/Sources/CryptoImplementation/DataRSAPrivateKey.swift
@@ -1,0 +1,68 @@
+//
+//  DataRSAPublicKey.swift
+//  JOSESwift
+//
+//  Created by Daniel Egger on 06.02.18.
+//  Modified by Luke Reichold on 08.12.20
+//
+//  ---------------------------------------------------------------------------
+//  Copyright 2019 Airside Mobile Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ---------------------------------------------------------------------------
+//
+
+import Foundation
+
+extension Data: ExpressibleAsRSAPrivateKeyComponents {
+    public static func representing(rsaPrivateKeyComponents components: RSAPrivateKeyComponents) throws -> Data {
+        var modulusBytes = [UInt8](components.modulus)
+        let exponentBytes = [UInt8](components.exponent)
+        let privateExponentBytes = [UInt8](components.privateExponent)
+
+        // Ensure the modulus is prefixed with 0x00.
+        if let prefix = modulusBytes.first, prefix != 0x00 {
+            modulusBytes.insert(0x00, at: 0)
+        }
+
+        let modulusEncoded = modulusBytes.encode(as: .integer)
+        let exponentEncoded = exponentBytes.encode(as: .integer)
+        let privateExponentEncoded = privateExponentBytes.encode(as: .integer)
+
+        let sequenceEncoded = (modulusEncoded + exponentEncoded + privateExponentEncoded).encode(as: .sequence)
+
+        return Data(sequenceEncoded)
+    }
+
+    // TODO: this will be wrong
+    public func rsaPrivateKeyComponents() throws -> RSAPrivateKeyComponents {
+        let publicKeyBytes = [UInt8](self)
+
+        let sequence = try publicKeyBytes.read(.sequence)
+        var modulus = try sequence.read(.integer)
+        let exponent = try sequence.skip(.integer).read(.integer)
+        let privateExponent = try sequence.skip(.integer).skip(.integer).read(.integer)
+
+        // Remove potential leading zero byte.
+        // See https://tools.ietf.org/html/rfc7518#section-6.3.1.1.
+        if modulus.first == 0x00 {
+            modulus = Array(modulus.dropFirst())
+        }
+
+        return (
+            Data(modulus),
+            Data(exponent),
+            Data(privateExponent)
+        )
+    }
+}

--- a/JOSESwift/Sources/CryptoImplementation/SecKeyRSAPrivateKey.swift
+++ b/JOSESwift/Sources/CryptoImplementation/SecKeyRSAPrivateKey.swift
@@ -1,0 +1,78 @@
+//
+//  SecKeyRSAPublicKey.swift
+//  JOSESwift
+//
+//  Created by Daniel Egger on 06.02.18.
+//  Modified by Luke Reichold on 08.12.20
+//  ---------------------------------------------------------------------------
+//  Copyright 2019 Airside Mobile Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ---------------------------------------------------------------------------
+//
+
+import Foundation
+import Security
+
+extension SecKey: ExpressibleAsRSAPrivateKeyComponents {
+    public static func representing(rsaPrivateKeyComponents components: RSAPrivateKeyComponents) throws -> Self {
+        return try instantiate(type: self, from: components)
+    }
+
+    // Generic helper function is needed so the compiler can infer the type of `Self`.
+    private static func instantiate<T>(type: T.Type, from components: RSAPrivateKeyComponents) throws -> T {
+        let keyData = try Data.representing(rsaPrivateKeyComponents: components)
+
+        // RSA key size is the number of bits of the modulus.
+        let keySize = (components.modulus.count * 8)
+
+        let attributes: [String: Any] = [
+            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+            kSecAttrKeyClass as String: kSecAttrKeyClassPrivate,
+            kSecAttrKeySizeInBits as String: keySize,
+            kSecAttrIsPermanent as String: false
+        ]
+
+        var error: Unmanaged<CFError>?
+        guard let keyReference = SecKeyCreateWithData(keyData as CFData, attributes as CFDictionary, &error) else {
+            // swiftlint:disable:next force_unwrapping
+            throw error!.takeRetainedValue() as Error
+        }
+
+        guard let key = keyReference as? T else {
+            throw JWKError.cannotConvertToSecKeyChildClasses
+        }
+
+        return key
+    }
+
+    public func rsaPrivateKeyComponents() throws -> RSAPrivateKeyComponents {
+        guard
+            let attributes = SecKeyCopyAttributes(self) as? [CFString: AnyObject],
+            let keyClass = attributes[kSecAttrKeyClass],
+            // All possible keyClasses are of type `CFString`.
+            // swiftlint:disable:next force_cast
+            keyClass as! CFString == kSecAttrKeyClassPrivate
+        else {
+            throw JWKError.notAPublicKey
+        }
+
+        var error: Unmanaged<CFError>?
+        guard let keyData = SecKeyCopyExternalRepresentation(self, &error) else {
+            // swiftlint:disable:next force_unwrapping
+            throw error!.takeRetainedValue() as Error
+        }
+
+        return try (keyData as Data).rsaPrivateKeyComponents()
+    }
+}

--- a/JOSESwift/Sources/CryptoImplementation/SecKeyRSAPrivateKey.swift
+++ b/JOSESwift/Sources/CryptoImplementation/SecKeyRSAPrivateKey.swift
@@ -36,15 +36,17 @@ extension SecKey: ExpressibleAsRSAPrivateKeyComponents {
         // RSA key size is the number of bits of the modulus.
         let keySize = (components.modulus.count * 8)
 
-        let attributes: [String: Any] = [
-            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
-            kSecAttrKeyClass as String: kSecAttrKeyClassPrivate,
-            kSecAttrKeySizeInBits as String: keySize,
-            kSecAttrIsPermanent as String: false
+        let attributes: [CFString: Any] = [
+            kSecAttrKeyType: kSecAttrKeyTypeRSA,
+            kSecAttrKeyClass: kSecAttrKeyClassPrivate,
+            kSecAttrKeySizeInBits: NSNumber(value: keySize),
+            kSecReturnPersistentRef: true
         ]
 
         var error: Unmanaged<CFError>?
-        guard let keyReference = SecKeyCreateWithData(keyData as CFData, attributes as CFDictionary, &error) else {
+        guard let keyReference = SecKeyCreateWithData(keyData as CFData,
+                                                      attributes as CFDictionary,
+                                                      &error) else {
             // swiftlint:disable:next force_unwrapping
             throw error!.takeRetainedValue() as Error
         }
@@ -64,7 +66,7 @@ extension SecKey: ExpressibleAsRSAPrivateKeyComponents {
             // swiftlint:disable:next force_cast
             keyClass as! CFString == kSecAttrKeyClassPrivate
         else {
-            throw JWKError.notAPublicKey
+            throw JWKError.notAPrivateKey
         }
 
         var error: Unmanaged<CFError>?

--- a/JOSESwift/Sources/JOSESwiftError.swift
+++ b/JOSESwift/Sources/JOSESwiftError.swift
@@ -44,6 +44,11 @@ public enum JOSESwiftError: Error {
     case exponentNotBase64URLUIntEncoded
     case privateExponentNotBase64URLUIntEncoded
     case symmetricKeyNotBase64URLEncoded
+    case prime1NotBase64URLEncoded
+    case prime2NotBase64URLEncoded
+    case exponent1NotBase64URLEncoded
+    case exponent2NotBase64URLEncoded
+    case coefficientNotBase64URLEncoded
 
     // EC coding errors
     case xNotBase64URLUIntEncoded

--- a/JOSESwift/Sources/JWKParameters.swift
+++ b/JOSESwift/Sources/JWKParameters.swift
@@ -49,6 +49,11 @@ public enum RSAParameter: String, CodingKey {
     case modulus = "n"
     case exponent = "e"
     case privateExponent = "d"
+    case prime1 = "p"
+    case prime2 = "q"
+    case exponent1 = "dp"
+    case exponent2 = "dq"
+    case coefficient = "qi"
 }
 
 /// Symmetric key specific JWK parameters.

--- a/JOSESwift/Sources/RSAKeyCodable.swift
+++ b/JOSESwift/Sources/RSAKeyCodable.swift
@@ -128,11 +128,21 @@ extension RSAPrivateKey: Decodable {
         let modulus = try rsaParameters.decode(String.self, forKey: .modulus)
         let exponent = try rsaParameters.decode(String.self, forKey: .exponent)
         let privateExponent = try rsaParameters.decode(String.self, forKey: .privateExponent)
+        let prime1 = try rsaParameters.decode(String.self, forKey: .prime1)
+        let prime2 = try rsaParameters.decode(String.self, forKey: .prime2)
+        let exponent1 = try rsaParameters.decode(String.self, forKey: .exponent1)
+        let exponent2 = try rsaParameters.decode(String.self, forKey: .exponent2)
+        let coefficient = try rsaParameters.decode(String.self, forKey: .coefficient)
 
         self.init(
             modulus: modulus,
             exponent: exponent,
             privateExponent: privateExponent,
+            prime1: prime1,
+            prime2: prime2,
+            exponent1: exponent1,
+            exponent2: exponent2,
+            coefficient: coefficient,
             additionalParameters: parameters
         )
     }

--- a/JOSESwift/Sources/RSAKeys.swift
+++ b/JOSESwift/Sources/RSAKeys.swift
@@ -229,13 +229,22 @@ public struct RSAPrivateKey: JWK {
     /// The exponent value for the RSA private key.
     public let exponent: String
 
-    /// The private exponent value for the RSA private key.
+    /// The private exponent (d) value for the RSA private key.
     public let privateExponent: String
 
+    /// The prime1 (p) value for the RSA private key.
     public let prime1: String
+
+    /// The prime2 (q) value for the RSA private key.
     public let prime2: String
+
+    /// The exponent1, used for CRT, (𝑑 mod 𝑝−1) value for the RSA private key.
     public let exponent1: String
+
+    /// The exponent2, used for CRT, (𝑑 mod 𝑞−1) value for the RSA private key.
     public let exponent2: String
+
+    /// The coefficient, used for CRT, (𝑞⁻¹ mod 𝑝) value for the RSA private key.
     public let coefficient: String
 
     /// Initializes a JWK containing an RSA private key.

--- a/JOSESwift/Sources/RSAKeys.swift
+++ b/JOSESwift/Sources/RSAKeys.swift
@@ -214,6 +214,7 @@ public struct RSAPrivateKey: JWK {
             JWKParameter.keyType.rawValue: self.keyType.rawValue,
             RSAParameter.modulus.rawValue: self.modulus,
             RSAParameter.exponent.rawValue: self.exponent,
+            RSAParameter.privateExponent.rawValue: self.privateExponent,
             RSAParameter.prime1.rawValue: self.prime1,
             RSAParameter.prime2.rawValue: self.prime2,
             RSAParameter.exponent1.rawValue: self.exponent1,


### PR DESCRIPTION
Sharing my implementation for initializing an `RSAPrivateKey` from a JWK token.

NOTE: with these additions, the legacy tests around `RSAPrivateKey` are failing, as this implementation requires all RSA fields to be provided (i.e. prime1, prime2, exponent1, exponent2, and coefficient) in addition to just `privateExponent`. I currently don't have the bandwidth to address these, but moving forward to remedy this I recommend adding support for initializing an `RSAPrivateKey` with only `modulus`, `exponent`, and `privateExponent`.

#helpWanted