### PR TITLE
Adding MacOS as supported platform in the Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "JOSESwift",
-    platforms: [.iOS(.v10)],
+    platforms: [.iOS(.v10), .macOS(.v10_15)],
     products: [
         .library(name: "JOSESwift", targets: ["JOSESwift"])
     ],


### PR DESCRIPTION
I needed to have the functionality of the framework available on Vapor project, therefore, I have added MacOS as platform. 