### PR TITLE
Prepare 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ Include references to issue- or pull-request numbers.
 ## [2.3.0] - 2020-11-11
 
 - Add parsed JWK header parameter (#240)
-- Update readme to mention macOS support (#234)
 - Apply Xcode12 recommended settings (#236)
 - Add macOS to platforms (#233)
 - Update danger (#232)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 Include references to issue- or pull-request numbers.
 
+## [2.3.0] - 2020-11-11
+
+- Add parsed JWK header parameter (#240)
+- Update readme to mention macOS support (#234)
+- Apply Xcode12 recommended settings (#236)
+- Adding macos to platforms (#233)
+- Update danger (#232)
+
 ## [2.2.1] - 2020-06-24
 
 - Copy additional parameters when updating JWT with keyId (#225)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Include references to issue- or pull-request numbers.
 - Add parsed JWK header parameter (#240)
 - Update readme to mention macOS support (#234)
 - Apply Xcode12 recommended settings (#236)
-- Adding macos to platforms (#233)
+- Add macOS to platforms (#233)
 - Update danger (#232)
 
 ## [2.2.1] - 2020-06-24

--- a/JOSESwift.podspec
+++ b/JOSESwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "JOSESwift"
-  s.version           = "2.2.1"
+  s.version           = "2.3.0"
   s.license           = "Apache License, Version 2.0"
   s.summary           = "JOSE framework for Swift"
   s.authors           = { "Daniel Egger" => "daniel.egger@airsidemobile.com", "Carol Capek" => "carol.capek@airsidemobile.com", "Christoph Gigi Fuchs" => "christoph.fuchs@airsidemobile.com" }

--- a/JOSESwift/Support/Info.plist
+++ b/JOSESwift/Support/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.1</string>
+	<string>2.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.1</string>
+	<string>2.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
- Add parsed JWK header parameter (#240)
- Apply Xcode12 recommended settings (#236)
- Add macOS to platforms (#233)
- Update danger (#232)