### PR TITLE
Stop installing SwiftLint when it's not installed

### DIFF
--- a/JOSESwift.xcodeproj/project.pbxproj
+++ b/JOSESwift.xcodeproj/project.pbxproj
@@ -713,7 +713,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint or run `brew bundle`\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint or run 'brew bundle'\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
The SwiftLint script run phase used backticks around "brew bundle" when
printing a message when SwiftLint is not installed. In shell,
expressions in backticks are evaluated, or in other words, executed.
So every time this script ran on a machine without Swiftlint installed
it basically install SwiftLint. This is not a desired behavior.