### PR TITLE
Automate publishing releases on GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,5 +87,3 @@ fastlane/test_output
 # Sonarqube
 .scannerwork
 
-# Vi
-.swp

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ fastlane/test_output
 
 # Sonarqube
 .scannerwork
+
+# Vi
+.swp

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -174,7 +174,7 @@ lane :publish_release do
   version = get_version_number(target: "JOSESwift")
 
   changelog = File.read("../CHANGELOG.md")
-  changes = changelog[/(- .+\(#.+\)\n)+/]
+  changes = changelog[/(- .+\(#.+\)\n)+/] # Filter latest change set (e.g. "- Add some feature (#123)\n...").
   tmp_changelog = Tempfile.new("jose-changelog")
   tmp_changelog.write(changes)
   tmp_changelog.close

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,4 +1,5 @@
-require 'fileutils'
+require "fileutils"
+require "tempfile"
 
 fastlane_version "2.63.0"
 
@@ -162,7 +163,25 @@ lane :release do
   # Puplish pod
   pod_push(path: "JOSESwift.podspec")
 
+  # Publish release
+  publish_release
+
   ensure_git_status_clean
+end
+
+desc "Publishes the release on GitHub"
+lane :publish_release do
+  version = get_version_number(target: "JOSESwift")
+
+  changelog = File.read("../CHANGELOG.md")
+  changes = changelog[/(- .+\(#.+\)\n)+/]
+  tmp_changelog = Tempfile.new("jose-changelog")
+  tmp_changelog.write(changes)
+  tmp_changelog.close
+
+  system("gh release create #{version} --title v#{version} --notes-file #{tmp_changelog.path}")
+
+  tmp_changelog.unlink
 end
 
 desc "Run Sonarqube analysis after running the test lane"


### PR DESCRIPTION
This will automatically publish a release including the latest changelog on GitHub when the `release` lane is run.

The latest release ([2.3.1](https://github.com/airsidemobile/JOSESwift/releases/tag/2.3.1)) was created using this lane.

Running the whole `release` lane on CI whenever a prepare pr is merged would be the next step in automating the release process.