### PR TITLE
Add support for JWS unencoded detached payloads

### DIFF
--- a/JOSESwift.xcodeproj/project.pbxproj
+++ b/JOSESwift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5C0F564327FF18C8006328D1 /* JWSSigningInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0F564227FF18C8006328D1 /* JWSSigningInput.swift */; };
 		5FB760497BB7711EFB470B5A /* ECKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB76A41AECF99F3673C1C40 /* ECKeys.swift */; };
 		5FB76093CE81BF1F8E7C254A /* JWKECDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB7625CF5EF5D8F2135967F /* JWKECDecodingTests.swift */; };
 		5FB7628EC6EA2C4263853DE9 /* DataECPrivateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB7604267B94DC5091D7105 /* DataECPrivateKey.swift */; };
@@ -139,6 +140,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5C0F564227FF18C8006328D1 /* JWSSigningInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JWSSigningInput.swift; sourceTree = "<group>"; };
 		5FB7604267B94DC5091D7105 /* DataECPrivateKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataECPrivateKey.swift; sourceTree = "<group>"; };
 		5FB760DB390F90F91102DB74 /* EC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EC.swift; sourceTree = "<group>"; };
 		5FB7625CF5EF5D8F2135967F /* JWKECDecodingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JWKECDecodingTests.swift; sourceTree = "<group>"; };
@@ -533,6 +535,7 @@
 			children = (
 				C85B1EF1204D82640026BDCB /* JWS.swift */,
 				6571F6221F7BF786004D53C5 /* JWSHeader.swift */,
+				5C0F564227FF18C8006328D1 /* JWSSigningInput.swift */,
 				C85B1EF3204D82860026BDCB /* Signer.swift */,
 				65D868101F7CEBA200769BBF /* Verifier.swift */,
 			);
@@ -859,6 +862,7 @@
 				5FB7641E9D67F245F52F3A7E /* EC.swift in Sources */,
 				5FB762CE28963B4780B33973 /* SecKeyECPublicKey.swift in Sources */,
 				5FB76E6F2080BEC6B63939D6 /* ECSigner.swift in Sources */,
+				5C0F564327FF18C8006328D1 /* JWSSigningInput.swift in Sources */,
 				5FB76B8D7F1214FF01FA1A8B /* ECVerifier.swift in Sources */,
 				5FB763AFF6BE04E8A6AE4DFC /* DataECPublicKey.swift in Sources */,
 				5FB7628EC6EA2C4263853DE9 /* DataECPrivateKey.swift in Sources */,

--- a/JOSESwift.xcodeproj/project.pbxproj
+++ b/JOSESwift.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5C0F564327FF18C8006328D1 /* JWSSigningInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0F564227FF18C8006328D1 /* JWSSigningInput.swift */; };
+		5C17840528181AD30072294E /* JWSUnencodedPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C17840428181AD30072294E /* JWSUnencodedPayloadTests.swift */; };
 		5FB760497BB7711EFB470B5A /* ECKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB76A41AECF99F3673C1C40 /* ECKeys.swift */; };
 		5FB76093CE81BF1F8E7C254A /* JWKECDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB7625CF5EF5D8F2135967F /* JWKECDecodingTests.swift */; };
 		5FB7628EC6EA2C4263853DE9 /* DataECPrivateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB7604267B94DC5091D7105 /* DataECPrivateKey.swift */; };
@@ -141,6 +142,7 @@
 
 /* Begin PBXFileReference section */
 		5C0F564227FF18C8006328D1 /* JWSSigningInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JWSSigningInput.swift; sourceTree = "<group>"; };
+		5C17840428181AD30072294E /* JWSUnencodedPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWSUnencodedPayloadTests.swift; sourceTree = "<group>"; };
 		5FB7604267B94DC5091D7105 /* DataECPrivateKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataECPrivateKey.swift; sourceTree = "<group>"; };
 		5FB760DB390F90F91102DB74 /* EC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EC.swift; sourceTree = "<group>"; };
 		5FB7625CF5EF5D8F2135967F /* JWKECDecodingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JWKECDecodingTests.swift; sourceTree = "<group>"; };
@@ -295,6 +297,7 @@
 				65125A311FBF85FA007CF3AE /* JWSDeserializationTests.swift */,
 				5FB765151D1E18BD7BFB95B8 /* JWSECTests.swift */,
 				7402BEB426288DCD0012801E /* JWSHMACTests.swift */,
+				5C17840428181AD30072294E /* JWSUnencodedPayloadTests.swift */,
 			);
 			name = JWS;
 			sourceTree = "<group>";
@@ -780,6 +783,7 @@
 				65125A321FBF85FA007CF3AE /* JWSDeserializationTests.swift in Sources */,
 				65A103A3202B0CDF00D22BF5 /* DataRSAPublicKeyTests.swift in Sources */,
 				C84BDE171FAB1CB60002B5D0 /* RSASignerTests.swift in Sources */,
+				5C17840528181AD30072294E /* JWSUnencodedPayloadTests.swift in Sources */,
 				C8EE14541FAC797500A616E4 /* RSAVerifierTests.swift in Sources */,
 				658261492029E2D200B594ED /* SecKeyRSAPublicKeyTests.swift in Sources */,
 				C86AC8CB1FCEC20F0007E611 /* AESCBCContentEncryptionTests.swift in Sources */,

--- a/JOSESwift/Sources/JWS.swift
+++ b/JOSESwift/Sources/JWS.swift
@@ -26,6 +26,7 @@ import Foundation
 internal enum JWSError: Error {
     case algorithmMismatch
     case cannotComputeSigningInput
+    case unencodedPayloadOptionMustNotBeUsedWithJWT
 }
 
 /// A JWS object consisting of a header, payload and signature. The three components of a JWS object

--- a/JOSESwift/Sources/JWS.swift
+++ b/JOSESwift/Sources/JWS.swift
@@ -111,6 +111,52 @@ public struct JWS {
         self = try JOSEDeserializer().deserialize(JWS.self, fromCompactSerialization: compactSerializationString)
     }
 
+    /// Constructs a JWS object from a given compact serialization string and a [detached payload](https://www.rfc-editor.org/rfc/rfc7515.html#appendix-F).
+    ///
+    /// If `compactSerialization` contains non-empty payload, `detachedPayload` is omitted.
+    ///
+    /// - Parameters:
+    ///   - compactSerialization: A compact serialized JWS object in string format as received e.g. from the server.
+    ///   - detachedPayload: A detached payload delivered outside the JWS context.
+    /// - Throws:
+    ///   - `JOSESwiftError.invalidCompactSerializationComponentCount(count: Int)`:
+    ///     If the component count of the compact serialization is wrong.
+    ///   - `JOSESwiftError.componentNotValidBase64URL(component: String)`:
+    ///     If the component is not a valid base64URL string.
+    ///   - `JOSESwiftError.componentCouldNotBeInitializedFromData(data: Data)`:
+    ///     If a component cannot be initialized from its data object.
+    public init(compactSerialization: String, detachedPayload: Payload) throws {
+        let jws = try JOSEDeserializer().deserialize(JWS.self, fromCompactSerialization: compactSerialization)
+        if jws.payload.data().isEmpty {
+            self.init(header: jws.header, payload: detachedPayload, signature: jws.signature)
+        } else {
+            self = jws
+        }
+    }
+
+    /// Constructs a JWS object from a given compact serialization data and a [detached payload](https://www.rfc-editor.org/rfc/rfc7515.html#appendix-F).
+    ///
+    /// If `compactSerialization` contains non-empty payload, `detachedPayload` is omitted.
+    ///
+    /// - Parameters:
+    ///   - compactSerialization: A compact serialized JWS object as data object as received e.g. from the server.
+    ///   - detachedPayload: A detached payload delivered outside the JWS context.
+    /// - Throws:
+    ///   - `JOSESwiftError.wrongDataEncoding(data: Data)`:
+    ///     If the compact serialization data object is not convertible to string.
+    ///   - `JOSESwiftError.invalidCompactSerializationComponentCount(count: Int)`:
+    ///     If the component count of the compact serialization is wrong.
+    ///   - `JOSESwiftError.componentNotValidBase64URL(component: String)`:
+    ///     If the component is not a valid base64URL string.
+    ///   - `JOSESwiftError.componentCouldNotBeInitializedFromData(data: Data)`:
+    ///     If a component cannot be initialized from its data object.
+    public init(compactSerialization: Data, detachedPayload: Payload) throws {
+        guard let compactSerializationString = String(data: compactSerialization, encoding: .utf8) else {
+            throw JOSESwiftError.wrongDataEncoding(data: compactSerialization)
+        }
+        try self.init(compactSerialization: compactSerializationString, detachedPayload: detachedPayload)
+    }
+
     fileprivate init(header: JWSHeader, payload: Payload, signature: Data) {
         self.header = header
         self.payload = payload
@@ -208,7 +254,13 @@ public struct JWS {
 extension JWS: CompactSerializable {
     public func serialize(to serializer: inout CompactSerializer) {
         serializer.serialize(header)
-        serializer.serialize(payload)
+
+        if header.crit?.contains("b64") == true, header.b64 == false {
+            serializer.serialize(Data()) // Detached payload.
+        } else {
+            serializer.serialize(payload)
+        }
+
         serializer.serialize(signature)
     }
 }

--- a/JOSESwift/Sources/JWSHeader.swift
+++ b/JOSESwift/Sources/JWSHeader.swift
@@ -223,6 +223,23 @@ extension JWSHeader: CommonHeaderParameterSpace {
         }
     }
 
+    /// The unencoded payload option.
+    ///
+    /// Reference: [](https://datatracker.ietf.org/doc/html/rfc7797#section-3).
+    ///
+    /// When set to `false` and `crit` contains `b64`, payload data is not encoded when computing the JWS signature.
+    ///
+    /// **NOTE**: Due to [Unencoded Payload Content Restrictions](https://datatracker.ietf.org/doc/html/rfc7797#section-5),
+    /// [detached payload](https://www.rfc-editor.org/rfc/rfc7515.html#appendix-F) is always used when serializing `JWS`.
+    public var b64: Bool? {
+        get {
+            return parameters["b64"] as? Bool
+        }
+        set {
+            parameters["b64"] = newValue
+        }
+    }
+
     /// The critical header parameter indicates the header parameter extensions.
     public var crit: [String]? {
         get {

--- a/JOSESwift/Sources/JWSSigningInput.swift
+++ b/JOSESwift/Sources/JWSSigningInput.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct JWSSigningInput {
+
+    let header: JWSHeader
+
+    let payload: Payload
+
+    func signingInput() throws -> Data {
+        let headerData = try computeHeaderData()
+        let payloadData = try computePayloadData()
+
+        // Force unwrapping is ok, since `".".data(using: .ascii)` should always work.
+        // swiftlint:disable:next force_unwrapping
+        return headerData + ".".data(using: .ascii)! + payloadData
+    }
+
+    private func computeHeaderData() throws -> Data {
+        guard let headerData = header.data().base64URLEncodedString().data(using: .ascii) else {
+            throw JWSError.cannotComputeSigningInput
+        }
+        return headerData
+    }
+
+    private func computePayloadData() throws -> Data {
+        let encodePayload = (header.crit?.contains("b64") == true)
+            ? (header.b64 ?? true)
+            : true
+
+        if encodePayload {
+            guard let encodedPayload = payload.data().base64URLEncodedString().data(using: .ascii) else {
+                throw JWSError.cannotComputeSigningInput
+            }
+            return encodedPayload
+        } else if let typ = header.typ, typ.caseInsensitiveCompare("jwt") == .orderedSame {
+            throw JWSError.unencodedPayloadOptionMustNotBeUsedWithJWT
+        } else {
+            return payload.data()
+        }
+    }
+
+}

--- a/JOSESwift/Sources/Signer.swift
+++ b/JOSESwift/Sources/Signer.swift
@@ -77,21 +77,9 @@ public struct Signer<KeyType> {
             throw JWSError.algorithmMismatch
         }
 
-        guard let signingInput = [header, payload].asJOSESigningInput() else {
-            throw JWSError.cannotComputeSigningInput
-        }
+        let signingInput = try JWSSigningInput(header: header, payload: payload).signingInput()
 
         return try signer.sign(signingInput)
-    }
-}
-
-extension Array where Element == DataConvertible {
-    func asJOSESigningInput() -> Data? {
-        let encoded = self.map { component in
-            return component.data().base64URLEncodedString()
-        }
-
-        return encoded.joined(separator: ".").data(using: .ascii)
     }
 }
 

--- a/JOSESwift/Sources/Verifier.swift
+++ b/JOSESwift/Sources/Verifier.swift
@@ -78,9 +78,7 @@ public struct Verifier {
             throw JWSError.algorithmMismatch
         }
 
-        guard let signingInput = [header, payload].asJOSESigningInput() else {
-            throw JWSError.cannotComputeSigningInput
-        }
+        let signingInput = try JWSSigningInput(header: header, payload: payload).signingInput()
 
         return try verifier.verify(signingInput, against: signature)
     }

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ You can find detailed information about the relevant JOSE standards in the respe
 - [RFC-7516:](https://tools.ietf.org/html/rfc7516) JSON Web Encryption (JWE)
 - [RFC-7517:](https://tools.ietf.org/html/rfc7517) JSON Web Key (JWK)
 - [RFC-7518:](https://tools.ietf.org/html/rfc7518) JSON Web Algorithms (JWA)
+- [RFC-7797:](https://datatracker.ietf.org/doc/html/rfc7797) JSON Web Signature (JWS) Unencoded Payload Option
 
 Don’t forget to check our [our wiki](https://github.com/mohemian/jose-ios/wiki) for more detailed documentation.
 

--- a/Tests/ECVerifierTests.swift
+++ b/Tests/ECVerifierTests.swift
@@ -41,7 +41,7 @@ class ECVerifierTests: ECCryptoTestCase {
         let jws = try! JWS(compactSerialization: serializedJWS)
         let verifier = ECVerifier(algorithm: algorithm, publicKey: keyData.publicKey)
 
-        guard let signingInput = [jws.header, jws.payload].asJOSESigningInput() else {
+        guard let signingInput = try? JWSSigningInput(header: jws.header, payload: jws.payload).signingInput() else {
             XCTFail()
             return false
         }

--- a/Tests/JWSHeaderTests.swift
+++ b/Tests/JWSHeaderTests.swift
@@ -111,7 +111,8 @@ class JWSHeaderTests: XCTestCase {
         let x5tS256 = "x5tS256"
         let typ = "typ"
         let cty = "cty"
-        let crit = ["crit1", "crit2"]
+        let b64 = false
+        let crit = ["crit1", "crit2", "b64"]
 
         var header = JWSHeader(algorithm: .RS512)
         header.jku = jku
@@ -123,6 +124,7 @@ class JWSHeaderTests: XCTestCase {
         header.x5tS256 = x5tS256
         header.typ = typ
         header.cty = cty
+        header.b64 = b64
         header.crit = crit
 
         XCTAssertEqual(header.data().count, try! JSONSerialization.data(withJSONObject: header.parameters, options: []).count)
@@ -153,6 +155,9 @@ class JWSHeaderTests: XCTestCase {
 
         XCTAssertEqual(header.parameters["cty"] as? String, cty)
         XCTAssertEqual(header.cty, cty)
+
+        XCTAssertEqual(header.parameters["b64"] as? Bool, b64)
+        XCTAssertEqual(header.b64, b64)
 
         XCTAssertEqual(header.parameters["crit"] as? [String], crit)
         XCTAssertEqual(header.crit, crit)

--- a/Tests/JWSSigningInputTest.swift
+++ b/Tests/JWSSigningInputTest.swift
@@ -42,8 +42,8 @@ class JWSSigningInputTest: XCTestCase {
         106, 112, 48, 99, 110, 86, 108, 102, 81
     ]
 
-    func testSigningInputComputation() {
-        let signingInput: [UInt8] = Array([header, payload].asJOSESigningInput()!)
+    func testSigningInputComputation() throws {
+        let signingInput: [UInt8] = Array(try JWSSigningInput(header: header, payload: payload).signingInput())
         XCTAssertEqual(signingInput, expectedSigningInput)
     }
 

--- a/Tests/JWSUnencodedPayloadTests.swift
+++ b/Tests/JWSUnencodedPayloadTests.swift
@@ -1,0 +1,103 @@
+// swiftlint:disable force_unwrapping
+
+import XCTest
+@testable import JOSESwift
+
+class JWSUnencodedPayloadTests: ECCryptoTestCase {
+
+    let detachedPayload = Payload("...DETACHED_ASCII_PAYLOAD...".data(using: .ascii)!)
+
+    let encodedPayload = "Li4uREVUQUNIRURfQVNDSUlfUEFZTE9BRC4uLg"
+
+    var signer: Signer<SecKey> {
+        Signer(signingAlgorithm: .ES256, key: allTestData.first!.privateKey)!
+    }
+
+    var verifier: Verifier {
+        Verifier(verifyingAlgorithm: .ES256, key: allTestData.first!.publicKey)!
+    }
+
+    func testCompactSerializationWithUnencodedPayloadOptionHasDetachedPayload() throws {
+        let header = try JWSHeader(parameters: [
+            "b64": false, // unencoded payload
+            "crit": ["b64"],
+            "alg": "ES256"
+        ])
+
+        let compactSerialization = try JWS(header: header, payload: detachedPayload, signer: signer).compactSerializedString
+        let components = compactSerialization.components(separatedBy: ".")
+
+        XCTAssertEqual(components.count, 3)
+        XCTAssertEqual(components[1], "") // payload is detached
+    }
+
+    func testCompactSerializationWithMissingCriticalHeaderHasEncodedPayload() throws {
+        let header = try JWSHeader(parameters: [
+            "b64": false, // unencoded payload
+            "crit": [], // "b64" not set
+            "alg": "ES256"
+        ])
+
+        let compactSerialization = try JWS(header: header, payload: detachedPayload, signer: signer).compactSerializedString
+        let components = compactSerialization.components(separatedBy: ".")
+
+        XCTAssertEqual(components[1], encodedPayload)
+    }
+
+    func testCompactSerializationWithExplicitlyEncodedPayloadHasEncodedPayload() throws {
+        let header = try JWSHeader(parameters: [
+            "b64": true, // explicitly encoded payload
+            "crit": ["b64"],
+            "alg": "ES256"
+        ])
+
+        let compactSerialization = try JWS(header: header, payload: detachedPayload, signer: signer).compactSerializedString
+        let components = compactSerialization.components(separatedBy: ".")
+
+        XCTAssertEqual(components[1], encodedPayload)
+    }
+
+    func testDeserializationAndValidityWithUnencodedDetachedPayload() throws {
+        let header = try JWSHeader(parameters: [
+            "b64": false, // unencoded payload
+            "crit": ["b64"],
+            "alg": "ES256"
+        ])
+
+        let compactSerialization = try JWS(header: header, payload: detachedPayload, signer: signer).compactSerializedString
+
+        let decoded = try JWS(compactSerialization: compactSerialization, detachedPayload: detachedPayload)
+
+        XCTAssertEqual(decoded.payload.data(), detachedPayload.data())
+        XCTAssertTrue(decoded.isValid(for: verifier))
+    }
+
+    func testDeserializationAndValidityWithEncodedDetachedPayload() throws {
+        let header = try JWSHeader(parameters: [
+            "alg": "ES256"
+        ])
+
+        let compactSerialization = try JWS(header: header, payload: detachedPayload, signer: signer).compactSerializedString
+        let components = compactSerialization.components(separatedBy: ".")
+        let compactSerializationWithDetachedPayload = "\(components[0])..\(components[2])"
+
+        let decoded = try JWS(compactSerialization: compactSerializationWithDetachedPayload, detachedPayload: detachedPayload)
+
+        XCTAssertEqual(decoded.payload.data(), detachedPayload.data())
+        XCTAssertTrue(decoded.isValid(for: verifier))
+    }
+
+    func testInitCompactSerializationWithPayloadAndDetachedPayloadIgnoresDetachedPayload() throws {
+        let header = try JWSHeader(parameters: [
+            "alg": "ES256"
+        ])
+
+        let payload = Payload("payload".data(using: .ascii)!)
+        let compactSerializationWithPayload = try JWS(header: header, payload: payload, signer: signer).compactSerializedString
+
+        let decoded = try JWS(compactSerialization: compactSerializationWithPayload, detachedPayload: detachedPayload)
+
+        XCTAssertEqual(decoded.payload.data(), payload.data())
+    }
+
+}

--- a/Tests/RSAVerifierTests.swift
+++ b/Tests/RSAVerifierTests.swift
@@ -44,7 +44,7 @@ class RSAVerifierTests: RSACryptoTestCase {
         let jws = try! JWS(compactSerialization: compactSerializedJWSRS512Const)
         let verifier = RSAVerifier(algorithm: .RS512, publicKey: publicKeyAlice2048!)
 
-        guard let signingInput = [jws.header, jws.payload].asJOSESigningInput() else {
+        guard let signingInput = try? JWSSigningInput(header: jws.header, payload: jws.payload).signingInput() else {
             XCTFail()
             return
         }


### PR DESCRIPTION
## Summary

Add option to skip base64url encoding of payload in JWS. This results in a compact serialization with [detached payload](https://www.rfc-editor.org/rfc/rfc7515.html#appendix-F).

Motivation for not encoding the payload is further described in [RFC-7797](https://datatracker.ietf.org/doc/html/rfc7797#section-1) _JSON Web Signature (JWS) Unencoded Payload Option_.

One example use case where unencoded payload is needed is implementing [`JsonWebSignature2020`](https://w3c-ccg.github.io/lds-jws2020/#suite-definition) for JSON-LD document proofs. In this case, JWS is used as a signature, and the document itself is not embedded in the JWS. This suite takes JSON-LD document & it's proof without signature, does some steps to normalize them, computes SHA-256 digests, concatenates them and forms a JWS from this result, without using base64url encoding. Finally, resulting JWS is added to the document proof segment, without payload. Verifying end can then reproduce the steps to create the payload for JWS and verify the signature.

## Changes

- Add [`"b64"`](https://datatracker.ietf.org/doc/html/rfc7797#section-3) header parameter support to `JWSHeader` to enable unencoded payload
- Replace `asJOSESigningInput()` with `JWSSigningInput` struct, which now contains the logic for signing input, controlled by `"b64"` header parameter
- Add support for initializing `JWS` with detached payload, to enable verification of (unencoded) detached payloads

## Caveats

- Due to [Unencoded Payload Content Restrictions](https://datatracker.ietf.org/doc/html/rfc7797#section-5), compact serialization of `JWS` with `"b64"` header parameter always yields a serialization with a detached payload. This was a choice to limit the scope of the PR to get minimum viable support for unencoded payload option.

## Remarks

Following tests were failing for me at `master` (d542b31):

- `testDecryptingAliceSecretWithBobKey()`
- `testDecryptingBobSecretWithAliceKey()`

These test failures are not related to changes in this PR.

## Tests

I found it a bit difficult to find a proper home for the unit tests of the added JWS functionality, so I chose to make a new test case class, `JWSUnencodedPayloadTests`, which was arbitrarily inherited from `ECCryptoTestCase` to get the required dependencies for signing & verifying.

I think these unit tests should be agnostic of the signature algorithm, but I couldn't find an easy way to do so without doing some bigger refactoring. If there's a simple way to mock `Signer`, please let me know.
