### PR TITLE
Private header parameters

### DIFF
--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -26,7 +26,7 @@ import Foundation
 /// The header of a `JWE` object.
 public struct JWEHeader: JOSEHeader {
     var headerData: Data
-    var parameters: [String: Any] {
+    public var parameters: [String: Any] {
         didSet {
             guard JSONSerialization.isValidJSONObject(parameters) else {
                 return

--- a/JOSESwift/Sources/JWSHeader.swift
+++ b/JOSESwift/Sources/JWSHeader.swift
@@ -26,7 +26,7 @@ import Foundation
 /// The header of a `JWS` object.
 public struct JWSHeader: JOSEHeader {
     var headerData: Data
-    var parameters: [String: Any] {
+    public var parameters: [String: Any] {
         didSet {
             guard JSONSerialization.isValidJSONObject(parameters) else {
                 return


### PR DESCRIPTION
### Summary
Enable the use of private header parameters by exposing the parameters dictionary

Private header parameters are currently not supported by JOSESwift. However, [RFC-7516](https://www.rfc-editor.org/rfc/rfc7516#section-4.3) describes their use. One way to support this is to publicly expose the parameters used by the JWEHeader and JWSHeader classes. This enables users of the library to extend the header classes with any custom parameters they require. 

### Changes
Makes the parameters dictionaries used by JWEHeader and JWSClasses public.

### Caveats
There might be reasons we do not want to allow direct access and modification of the parameters variable on headers. In that case, a different implementation is needed to comply with [RFC-7516](https://www.rfc-editor.org/rfc/rfc7516#section-4.3). Any and all feedback is welcome.

### Tests
The tests pass. No changes needed.