### PR TITLE
Fix linter warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -18,6 +18,9 @@ disabled_rules:
   - todo
   - no_space_in_method_call
 
+large_tuple: 
+  error: 5
+
 opt_in_rules:
   - force_unwrapping
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -18,8 +18,7 @@ disabled_rules:
   - todo
   - no_space_in_method_call
 
-large_tuple: 
-  error: 5
+large_tuple: 5
 
 opt_in_rules:
   - force_unwrapping

--- a/JOSESwift/Sources/RSAKeys.swift
+++ b/JOSESwift/Sources/RSAKeys.swift
@@ -228,7 +228,7 @@ public struct RSAPrivateKey: JWK {
     ///              as specified in [RFC-7518, Section 2](https://tools.ietf.org/html/rfc7518#section-2).
     ///   - exponent: The exponent value for the RSA private key in `base64urlUInt` encoding
     ///               as specified in [RFC-7518, Section 2](https://tools.ietf.org/html/rfc7518#section-2).
-    //    - privateExponent: The private exponent value for the RSA private key in `base64urlUInt` encoding
+    ///    - privateExponent: The private exponent value for the RSA private key in `base64urlUInt` encoding
     ///               as specified in [RFC-7518, Section 2](https://tools.ietf.org/html/rfc7518#section-2).
     ///   - parameters: Additional JWK parameters.
     public init(modulus: String, exponent: String, privateExponent: String, additionalParameters parameters: [String: String] = [:]) {

--- a/Tests/AESCBCContentDecryptionTests.swift
+++ b/Tests/AESCBCContentDecryptionTests.swift
@@ -151,3 +151,4 @@ class AESCBCContentDecryptionTests: XCTestCase {
         XCTAssertEqual(plaintext, testPlaintext)
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/AESCBCContentEncryptionTests.swift
+++ b/Tests/AESCBCContentEncryptionTests.swift
@@ -235,3 +235,4 @@ class AESCBCContentEncryptionTests: XCTestCase {
         XCTAssertEqual(cryptData, plaintext)
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/AESKeyWrapKeyManagementModeTests.swift
+++ b/Tests/AESKeyWrapKeyManagementModeTests.swift
@@ -234,3 +234,4 @@ private func ccAESKeyUnwrap(
 
     return (rawKey, status)
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/AESKeyWrapTests.swift
+++ b/Tests/AESKeyWrapTests.swift
@@ -166,3 +166,4 @@ class AESKeyWrapTests: XCTestCase {
         }
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/ASN1DERParsingTests.swift
+++ b/Tests/ASN1DERParsingTests.swift
@@ -273,3 +273,4 @@ class ASN1DERParsingTests: XCTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/CryptoTestCase.swift
+++ b/Tests/CryptoTestCase.swift
@@ -88,3 +88,4 @@ extension Data {
             .joined(separator: "")
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/DataExtensionTests.swift
+++ b/Tests/DataExtensionTests.swift
@@ -184,3 +184,4 @@ class DataExtensionTests: XCTestCase {
         XCTAssertEqual(false, testData1._timingSafeCompare(with: testData2))
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/DataRSAPublicKeyTests.swift
+++ b/Tests/DataRSAPublicKeyTests.swift
@@ -93,3 +93,4 @@ class DataRSAPublicKeyTests: RSACryptoTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/DirectEncryptionKeyManagementModeTests.swift
+++ b/Tests/DirectEncryptionKeyManagementModeTests.swift
@@ -47,3 +47,4 @@ class DirectEncryptionKeyManagementModeTests: XCTestCase {
         XCTAssertEqual(encryptedKey, Data())
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/ECCryptoTestCase.swift
+++ b/Tests/ECCryptoTestCase.swift
@@ -270,3 +270,4 @@ class ECCryptoTestCase: CryptoTestCase {
         // do nothing: setup happens in the construction of the ECTestKeyData instances
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/ECPrivateKeyToSecKeyTests.swift
+++ b/Tests/ECPrivateKeyToSecKeyTests.swift
@@ -66,3 +66,4 @@ class ECPrivateKeyToSecKeyTests: ECCryptoTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/ECPublicKeyToDataTests.swift
+++ b/Tests/ECPublicKeyToDataTests.swift
@@ -40,3 +40,4 @@ class ECPublicKeyToDataTests: ECCryptoTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/ECPublicKeyToSecKeyTests.swift
+++ b/Tests/ECPublicKeyToSecKeyTests.swift
@@ -62,3 +62,4 @@ class ECPublicKeyToSecKeyTests: ECCryptoTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/ECSignerTests.swift
+++ b/Tests/ECSignerTests.swift
@@ -56,3 +56,4 @@ class ECSignerTests: ECCryptoTestCase {
         _testSigning(algorithm: .ES512, keyData: p521)
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/EncrypterDecrypterInitializationTests.swift
+++ b/Tests/EncrypterDecrypterInitializationTests.swift
@@ -218,3 +218,4 @@ class EncrypterDecrypterInitializationTests: RSACryptoTestCase {
         }
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/HMACCryptoTestCase.swift
+++ b/Tests/HMACCryptoTestCase.swift
@@ -67,3 +67,4 @@ class HMACCryptoTestCase: CryptoTestCase {
         // do nothing
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/HMACTests.swift
+++ b/Tests/HMACTests.swift
@@ -92,3 +92,4 @@ class HMACTests: HMACCryptoTestCase {
         XCTAssertNotEqual(hmacOutput, hmac512TestOutput)
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWEAESKeyWrapTests.swift
+++ b/Tests/JWEAESKeyWrapTests.swift
@@ -74,3 +74,4 @@ class JWEAESKeyWrapTests: XCTestCase {
         XCTAssertThrowsError(try jwe.decrypt(using: decyrpter))
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWECompressionTests.swift
+++ b/Tests/JWECompressionTests.swift
@@ -140,3 +140,5 @@ class JWECompressionTests: RSACryptoTestCase {
         XCTAssertEqual(try deflateCompressor.decompress(data: compressedData), data)
     }
 }
+// swiftlint:enable force_unwrapping
+// swiftlint:enable force_cast

--- a/Tests/JWEDeserializationTests.swift
+++ b/Tests/JWEDeserializationTests.swift
@@ -125,3 +125,4 @@ class JWEDeserializationTests: XCTestCase {
         XCTFail()
     }
 }
+// swiftlint:disable force_unwrapping

--- a/Tests/JWEDeserializationTests.swift
+++ b/Tests/JWEDeserializationTests.swift
@@ -125,4 +125,4 @@ class JWEDeserializationTests: XCTestCase {
         XCTFail()
     }
 }
-// swiftlint:disable force_unwrapping
+// swiftlint:enable force_unwrapping

--- a/Tests/JWEDirectEncryptionTests.swift
+++ b/Tests/JWEDirectEncryptionTests.swift
@@ -156,3 +156,4 @@ class JWEDirectEncryptionTests: RSACryptoTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWEHeaderTests.swift
+++ b/Tests/JWEHeaderTests.swift
@@ -319,3 +319,4 @@ class JWEHeaderTests: XCTestCase {
         XCTAssertEqual(jwk.modulus, headerJwk?.modulus)
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWERSATests.swift
+++ b/Tests/JWERSATests.swift
@@ -304,3 +304,4 @@ class JWERSATests: RSACryptoTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWKECDecodingTests.swift
+++ b/Tests/JWKECDecodingTests.swift
@@ -288,3 +288,4 @@ class JWKECDecodingTests: ECCryptoTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWKECEncodingTests.swift
+++ b/Tests/JWKECEncodingTests.swift
@@ -117,3 +117,4 @@ class JWKECEncodingTests: ECCryptoTestCase {
         XCTAssertEqual(dict["y"] as? String ?? "", keyData.expectedYCoordinateBase64Url)
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWKECKeysTests.swift
+++ b/Tests/JWKECKeysTests.swift
@@ -262,3 +262,4 @@ class JWKECKeysTests: ECCryptoTestCase {
         }
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWKRSADecodingTests.swift
+++ b/Tests/JWKRSADecodingTests.swift
@@ -379,3 +379,4 @@ class JWKRSADecodingTests: RSACryptoTestCase {
         XCTAssertNoThrow(try JWKSet(data: json))
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWKRSAEncodingTests.swift
+++ b/Tests/JWKRSAEncodingTests.swift
@@ -117,3 +117,4 @@ class JWKRSAEncodingTests: RSACryptoTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWKRSAKeysTests.swift
+++ b/Tests/JWKRSAKeysTests.swift
@@ -163,3 +163,4 @@ class JWKRSAKeysTests: RSACryptoTestCase {
         XCTAssertEqual(jwk.parameters[JWKParameter.keyUse.rawValue], useKey)
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWKSetCodingTests.swift
+++ b/Tests/JWKSetCodingTests.swift
@@ -428,3 +428,4 @@ class JWKSetCodingTests: XCTestCase {
         XCTAssertEqual(jwkSet.jsonString()!.count, String(data: testDataTwoRSAPublicKeys, encoding: .utf8)!.count)
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWKtoJSONTests.swift
+++ b/Tests/JWKtoJSONTests.swift
@@ -68,3 +68,4 @@ class JWKtoJSONTests: RSACryptoTestCase {
         XCTAssertEqual(dict!["e"] as? String ?? "", expectedExponentBase64)
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWSDeserializationTests.swift
+++ b/Tests/JWSDeserializationTests.swift
@@ -106,3 +106,4 @@ class JWSDeserializationTests: XCTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWSECTests.swift
+++ b/Tests/JWSECTests.swift
@@ -77,3 +77,4 @@ class JWSECTests: ECCryptoTestCase {
         XCTAssertEqual(payload, plainTextPayload)
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWSHMACTests.swift
+++ b/Tests/JWSHMACTests.swift
@@ -63,3 +63,4 @@ class JWSHMACTests: HMACCryptoTestCase {
         _testHMACSerializationValidationAndDeserialization(algorithm: .HS512)
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWSHeaderTests.swift
+++ b/Tests/JWSHeaderTests.swift
@@ -231,3 +231,4 @@ class JWSHeaderTests: XCTestCase {
         XCTAssertEqual(jwk.modulus, headerJwk?.modulus)
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWSRSATests.swift
+++ b/Tests/JWSRSATests.swift
@@ -146,3 +146,4 @@ class JWSRSATests: RSACryptoTestCase {
         }
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWSSigningInputTest.swift
+++ b/Tests/JWSSigningInputTest.swift
@@ -48,3 +48,4 @@ class JWSSigningInputTest: XCTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/JWSValidationTests.swift
+++ b/Tests/JWSValidationTests.swift
@@ -253,3 +253,4 @@ extension JOSESwiftError: Equatable {
         }
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/RSACryptoTestCase.swift
+++ b/Tests/RSACryptoTestCase.swift
@@ -187,3 +187,4 @@ class RSACryptoTestCase: CryptoTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/RSADecryptionTests.swift
+++ b/Tests/RSADecryptionTests.swift
@@ -245,3 +245,4 @@ class RSADecryptionTests: RSACryptoTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/RSAEncryptionTests.swift
+++ b/Tests/RSAEncryptionTests.swift
@@ -180,3 +180,4 @@ class RSAEncryptionTests: RSACryptoTestCase {
         }
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/RSAKeyManagementModeTests.swift
+++ b/Tests/RSAKeyManagementModeTests.swift
@@ -178,3 +178,4 @@ class RSAKeyManagementModeTests: RSACryptoTestCase {
         }
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/RSAPublicKeyToSecKeyTests.swift
+++ b/Tests/RSAPublicKeyToSecKeyTests.swift
@@ -54,3 +54,4 @@ class RSAPublicKeyToSecKeyTests: RSACryptoTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/RSASignerTests.swift
+++ b/Tests/RSASignerTests.swift
@@ -51,3 +51,4 @@ class RSASignerTests: RSACryptoTestCase {
         XCTAssertEqual(signature.base64URLEncodedString(), signatureBase64URL)
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/RSAVerifierTests.swift
+++ b/Tests/RSAVerifierTests.swift
@@ -53,3 +53,4 @@ class RSAVerifierTests: RSACryptoTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/SecKeyECPrivateKeyTests.swift
+++ b/Tests/SecKeyECPrivateKeyTests.swift
@@ -80,3 +80,4 @@ class SecKeyECPrivateKeyTests: ECCryptoTestCase {
         }
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/SecKeyECPublicKeyTests.swift
+++ b/Tests/SecKeyECPublicKeyTests.swift
@@ -73,3 +73,4 @@ class SecKeyECPublicKeyTests: ECCryptoTestCase {
         }
     }
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/SecKeyRSAPublicKeyTests.swift
+++ b/Tests/SecKeyRSAPublicKeyTests.swift
@@ -123,3 +123,4 @@ class SecKeyRSAPublicKeyTests: RSACryptoTestCase {
     }
 
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/SymmetricKeyTests.swift
+++ b/Tests/SymmetricKeyTests.swift
@@ -166,3 +166,4 @@ class SymmetricKeyTests: XCTestCase {
         XCTAssertEqual(jwk.parameters[JWKParameter.algorithm.rawValue], ContentEncryptionAlgorithm.A256CBCHS512.rawValue)
     }
 }
+// swiftlint:enable force_unwrapping


### PR DESCRIPTION
fixes: #292 

## Description

Fix carthage build error by setting Swiftlint `large_tuple` rule to pop an error only when we have more than 5 params in a tuple.
 

