### PR TITLE
Add support for public and private header parameters

### DIFF
--- a/JOSESwift/Sources/JOSEHeader.swift
+++ b/JOSESwift/Sources/JOSEHeader.swift
@@ -48,7 +48,7 @@ extension JOSEHeader {
             throw JOSESwiftError.invalidHeaderParameterValue
         }
 
-        guard JSONSerialization.isValidJSONObject([parameterName: value]) else{
+        guard JSONSerialization.isValidJSONObject([parameterName: value]) else {
             throw JOSESwiftError.invalidHeaderParameterValue
         }
 

--- a/JOSESwift/Sources/JOSEHeader.swift
+++ b/JOSESwift/Sources/JOSEHeader.swift
@@ -43,7 +43,7 @@ protocol JOSEHeader: DataConvertible, CommonHeaderParameterSpace {
 }
 
 extension JOSEHeader {
-    mutating func set(_ value: Any, forParameter parameterName: String) throws {
+    public mutating func set(_ value: Any, forParameter parameterName: String) throws {
         guard !requiredParameters.contains(parameterName) else {
             throw JOSESwiftError.invalidHeaderParameterValue
         }
@@ -55,11 +55,11 @@ extension JOSEHeader {
         parameters[parameterName] = value
     }
 
-    func get(parameter parameterName: String) -> Any? {
+    public func get(parameter parameterName: String) -> Any? {
         return parameters[parameterName]
     }
 
-    @discardableResult mutating func remove(parameter parameterName: String) -> Any? {
+    @discardableResult public mutating func remove(parameter parameterName: String) -> Any? {
         guard !requiredParameters.contains(parameterName) else {
             return nil
         }

--- a/JOSESwift/Sources/JOSEHeader.swift
+++ b/JOSESwift/Sources/JOSEHeader.swift
@@ -32,12 +32,40 @@ enum HeaderParsingError: Error {
 /// Moreover, a `JOSEHeader` is a `JOSEObjectComponent`. Therefore it can be initialized from and converted to `Data`.
 protocol JOSEHeader: DataConvertible, CommonHeaderParameterSpace {
     var headerData: Data { get }
-    var parameters: [String: Any] { get }
+    var parameters: [String: Any] { get set }
+
+    var requiredParameters: [String] { get }
 
     init(parameters: [String: Any], headerData: Data) throws
 
     init?(_ data: Data)
     func data() -> Data
+}
+
+extension JOSEHeader {
+    mutating func set(_ value: Any, forParameter parameterName: String) throws {
+        guard !requiredParameters.contains(parameterName) else {
+            throw JOSESwiftError.invalidHeaderParameterValue
+        }
+
+        guard JSONSerialization.isValidJSONObject([parameterName: value]) else{
+            throw JOSESwiftError.invalidHeaderParameterValue
+        }
+
+        parameters[parameterName] = value
+    }
+
+    func get(parameter parameterName: String) -> Any? {
+        return parameters[parameterName]
+    }
+
+    @discardableResult mutating func remove(parameter parameterName: String) -> Any? {
+        guard !requiredParameters.contains(parameterName) else {
+            return nil
+        }
+
+        return parameters.removeValue(forKey: parameterName)
+    }
 }
 
 // `DataConvertible` implementation.

--- a/JOSESwift/Sources/JOSESwiftError.swift
+++ b/JOSESwift/Sources/JOSESwiftError.swift
@@ -63,4 +63,7 @@ public enum JOSESwiftError: Error {
 
     // Thumprint computation
     case thumbprintSerialization
+
+    // Header errors
+    case invalidHeaderParameterValue
 }

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -85,8 +85,10 @@ public struct JWEHeader: JOSEHeader {
 
     /// Initializes a `JWEHeader` with the specified parameters.
     public init(parameters: [String: Any]) throws {
-        let headerData = try JSONSerialization.data(withJSONObject: parameters, options: [.sortedKeys])
-        try self.init(parameters: parameters, headerData: headerData)
+        try self.init(
+            parameters: parameters,
+            headerData: try JSONSerialization.data(withJSONObject: parameters, options: [.sortedKeys])
+        )
     }
 }
 

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -33,7 +33,7 @@ public struct JWEHeader: JOSEHeader {
             }
             // Forcing the try is ok here, because it is valid JSON.
             // swiftlint:disable:next force_try
-            headerData = try! JSONSerialization.data(withJSONObject: parameters, options: [])
+            headerData = try! JSONSerialization.data(withJSONObject: parameters, options: [.sortedKeys])
         }
     }
 
@@ -73,18 +73,15 @@ public struct JWEHeader: JOSEHeader {
             "enc": contentEncryptionAlgorithm.rawValue
         ]
 
-        // Forcing the try is ok here, since [String: String] can be converted to JSON.
+        // Forcing the try is ok here, since [String: String] can be converted to JSON and "alg" and "enc" are the only required
+        // header parameters, which should pass the guard conditions in the main initializer
         // swiftlint:disable:next force_try
-        let headerData = try! JSONSerialization.data(withJSONObject: parameters, options: [])
-
-        // Forcing the try is ok here, since "alg" and "enc" are the only required header parameters.
-        // swiftlint:disable:next force_try
-        try! self.init(parameters: parameters, headerData: headerData)
+        try! self.init(parameters: parameters)
     }
 
     /// Initializes a `JWEHeader` with the specified parameters.
     public init(parameters: [String: Any]) throws {
-        let headerData = try JSONSerialization.data(withJSONObject: parameters, options: [])
+        let headerData = try JSONSerialization.data(withJSONObject: parameters, options: [.sortedKeys])
         try self.init(parameters: parameters, headerData: headerData)
     }
 }

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -28,7 +28,9 @@ public struct JWEHeader: JOSEHeader {
     var headerData: Data
     var parameters: [String: Any] {
         didSet {
+            print("update: \(parameters)")
             guard JSONSerialization.isValidJSONObject(parameters) else {
+                assertionFailure("header parameters are invalid json...")
                 return
             }
             // Forcing the try is ok here, because it is valid JSON.
@@ -36,6 +38,8 @@ public struct JWEHeader: JOSEHeader {
             headerData = try! JSONSerialization.data(withJSONObject: parameters, options: [.sortedKeys])
         }
     }
+
+    var requiredParameters = ["alg", "enc"]
 
     /// Initializes a JWE header with given parameters and their original `Data` representation.
     /// Note that this (base64-url decoded) `Data` representation has to be exactly as it was

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -28,7 +28,6 @@ public struct JWEHeader: JOSEHeader {
     var headerData: Data
     var parameters: [String: Any] {
         didSet {
-            print("update: \(parameters)")
             guard JSONSerialization.isValidJSONObject(parameters) else {
                 assertionFailure("header parameters are invalid json...")
                 return

--- a/JOSESwift/Sources/JWEHeader.swift
+++ b/JOSESwift/Sources/JWEHeader.swift
@@ -38,6 +38,7 @@ public struct JWEHeader: JOSEHeader {
         }
     }
 
+    // See https://www.rfc-editor.org/rfc/rfc7516#section-4.1
     var requiredParameters = ["alg", "enc"]
 
     /// Initializes a JWE header with given parameters and their original `Data` representation.

--- a/JOSESwift/Sources/JWSHeader.swift
+++ b/JOSESwift/Sources/JWSHeader.swift
@@ -33,7 +33,7 @@ public struct JWSHeader: JOSEHeader {
             }
             // Forcing the try is ok here, because it is valid JSON.
             // swiftlint:disable:next force_try
-            headerData = try! JSONSerialization.data(withJSONObject: parameters, options: [])
+            headerData = try! JSONSerialization.data(withJSONObject: parameters, options: [.sortedKeys])
         }
     }
 
@@ -73,7 +73,7 @@ public struct JWSHeader: JOSEHeader {
 
     /// Initializes a `JWSHeader` with the specified parameters.
     public init(parameters: [String: Any]) throws {
-        let headerData = try JSONSerialization.data(withJSONObject: parameters, options: [])
+        let headerData = try JSONSerialization.data(withJSONObject: parameters, options: [.sortedKeys])
         try self.init(parameters: parameters, headerData: headerData)
     }
 }

--- a/JOSESwift/Sources/JWSHeader.swift
+++ b/JOSESwift/Sources/JWSHeader.swift
@@ -37,6 +37,7 @@ public struct JWSHeader: JOSEHeader {
         }
     }
 
+    // See https://www.rfc-editor.org/rfc/rfc7515#section-4.1
     var requiredParameters = ["alg"]
 
     /// Initializes a JWS header with given parameters and their original `Data` representation.

--- a/JOSESwift/Sources/JWSHeader.swift
+++ b/JOSESwift/Sources/JWSHeader.swift
@@ -75,8 +75,10 @@ public struct JWSHeader: JOSEHeader {
 
     /// Initializes a `JWSHeader` with the specified parameters.
     public init(parameters: [String: Any]) throws {
-        let headerData = try JSONSerialization.data(withJSONObject: parameters, options: [.sortedKeys])
-        try self.init(parameters: parameters, headerData: headerData)
+        try self.init(
+            parameters: parameters,
+            headerData: try JSONSerialization.data(withJSONObject: parameters, options: [.sortedKeys])
+        )
     }
 }
 

--- a/JOSESwift/Sources/JWSHeader.swift
+++ b/JOSESwift/Sources/JWSHeader.swift
@@ -37,6 +37,8 @@ public struct JWSHeader: JOSEHeader {
         }
     }
 
+    var requiredParameters = ["alg"]
+
     /// Initializes a JWS header with given parameters and their original `Data` representation.
     /// Note that this (base64-url decoded) `Data` representation has to be exactly as it was
     /// received from the sender in order to guarantee correctness of signature validations.

--- a/README.md
+++ b/README.md
@@ -152,15 +152,23 @@ In order to construct a JWS we need to provide the following parts:
 ##### Header
 
 ``` swift
-let header = JWSHeader(algorithm: .RS512)
+var header = JWSHeader(algorithm: .RS512)
 ```
 
-Optionally you can set [addtitional parameters](https://tools.ietf.org/html/rfc7515#section-4.1):
+You can set [registered header parameters](https://tools.ietf.org/html/rfc7515#section-4.1) via convenient accessors:
 
 ``` swift
 header.kid = "2018-10-08"
 
 header.typ = "JWS"
+```
+
+[Public](https://tools.ietf.org/html/rfc7515#section-4.2) and [private](https://tools.ietf.org/html/rfc7515#section-4.3) header parameters can be set and read like so:
+
+``` swift
+try header.set("rice", forParameter: "meal")
+let meal = header.get(parameter: "meal") // "rice"
+header.remove(parameter: "meal")
 ```
 
 ##### Payload
@@ -231,15 +239,23 @@ In order to construct a JWE we need to provide the following parts:
 ##### Header
 
 ``` swift
-let header = JWEHeader(keyManagementAlgorithm: .RSA1_5, contentEncryptionAlgorithm: .A256CBCHS512)
+var header = JWEHeader(keyManagementAlgorithm: .RSA1_5, contentEncryptionAlgorithm: .A256CBCHS512)
 ```
 
-Optionally you can set [addtitional parameters](https://tools.ietf.org/html/rfc7516#section-4.1):
+You can set [registered header parameters](https://tools.ietf.org/html/rfc7516#section-4.1):
 
 ``` swift
 header.kid = "2018-10-08"
 
 header.typ = "JWE"
+```
+
+[Public](https://tools.ietf.org/html/rfc7515#section-4.2) and [private](https://tools.ietf.org/html/rfc7515#section-4.3) header parameters can be set and read like so:
+
+``` swift
+try header.set("rice", forParameter: "meal")
+let meal = header.get(parameter: "meal") // "rice"
+header.remove(parameter: "meal")
 ```
 
 ##### Payload

--- a/Tests/JWEHeaderTests.swift
+++ b/Tests/JWEHeaderTests.swift
@@ -345,7 +345,7 @@ class JWEHeaderTests: XCTestCase {
         XCTAssertEqual(header.get(parameter: "int") as! Int, Int.max)
         XCTAssertEqual(header.get(parameter: "bool") as! Bool, true)
         XCTAssertEqual(header.get(parameter: "arary") as! [String], ["one", "two", "three"])
-        XCTAssertEqual(header.get(parameter: "dict") as! [String : Int], ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(header.get(parameter: "dict") as! [String: Int], ["one": 1, "two": 2, "three": 3])
 
         // backing data representation is as expected
         var expectedValue = parameterDictRSA as [String: Any]
@@ -395,7 +395,6 @@ class JWEHeaderTests: XCTestCase {
         XCTAssertEqual(header.get(parameter: "string") as! String, "string")
         XCTAssertTrue(String(data: header.data(), encoding: .utf8)!.contains("string"))
         XCTAssertTrue(String(data: header.data(), encoding: .utf8)!.contains("kid"))
-
 
     }
 

--- a/Tests/JWEHeaderTests.swift
+++ b/Tests/JWEHeaderTests.swift
@@ -27,16 +27,16 @@ import XCTest
 
 class JWEHeaderTests: XCTestCase {
     let parameterDictRSA = ["alg": "RSA1_5", "enc": "A256CBC-HS512"]
-    let parameterDataRSA = try! JSONSerialization.data(withJSONObject: ["alg": "RSA1_5", "enc": "A256CBC-HS512"], options: [])
+    let parameterDataRSA = try! JSONSerialization.data(withJSONObject: ["alg": "RSA1_5", "enc": "A256CBC-HS512"], options: [.sortedKeys])
 
     let parameterDictRSAOAEP = ["alg": "RSA-OAEP", "enc": "A256CBC-HS512"]
-    let parameterDataRSAOAEP = try! JSONSerialization.data(withJSONObject: ["alg": "RSA-OAEP", "enc": "A256CBC-HS512"], options: [])
+    let parameterDataRSAOAEP = try! JSONSerialization.data(withJSONObject: ["alg": "RSA-OAEP", "enc": "A256CBC-HS512"], options: [.sortedKeys])
 
     let parameterDictRSAOAEP256 = ["alg": "RSA-OAEP-256", "enc": "A256CBC-HS512"]
-    let parameterDataRSAOAEP256 = try! JSONSerialization.data(withJSONObject: ["alg": "RSA-OAEP-256", "enc": "A256CBC-HS512"], options: [])
+    let parameterDataRSAOAEP256 = try! JSONSerialization.data(withJSONObject: ["alg": "RSA-OAEP-256", "enc": "A256CBC-HS512"], options: [.sortedKeys])
 
     let parameterDictDirect = ["alg": "dir", "enc": "A256CBC-HS512"]
-    let parameterDataDirect = try! JSONSerialization.data(withJSONObject: ["alg": "dir", "enc": "A256CBC-HS512"], options: [])
+    let parameterDataDirect = try! JSONSerialization.data(withJSONObject: ["alg": "dir", "enc": "A256CBC-HS512"], options: [.sortedKeys])
 
     override func setUp() {
         super.setUp()

--- a/Tests/JWEHeaderTests.swift
+++ b/Tests/JWEHeaderTests.swift
@@ -318,5 +318,117 @@ class JWEHeaderTests: XCTestCase {
         XCTAssertEqual(jwk.exponent, headerJwk?.exponent)
         XCTAssertEqual(jwk.modulus, headerJwk?.modulus)
     }
+
+    func testSettingAndGettingPublicPrivateHeaderParameters() throws {
+        var header = JWEHeader(keyManagementAlgorithm: .RSA1_5, contentEncryptionAlgorithm: .A256CBCHS512)
+
+        // registered header parameter (RFC-7516, 4.1)
+        try header.set("123", forParameter: "kid")
+
+        // public or private header parameters (RFC-7516, 4.2 and 4.3)
+        try header.set("string", forParameter: "string")
+        try header.set(Float.pi, forParameter: "float")
+        try header.set(Double.pi, forParameter: "double")
+        try header.set(Int.max, forParameter: "int")
+        try header.set(true, forParameter: "bool")
+        try header.set(["one", "two", "three"], forParameter: "arary")
+        try header.set(["one": 1, "two": 2, "three": 3], forParameter: "dict")
+
+        // all parameters can be retrieved
+
+        XCTAssertEqual(header.get(parameter: "alg") as? String, KeyManagementAlgorithm.RSA1_5.rawValue)
+        XCTAssertEqual(header.get(parameter: "enc") as? String, ContentEncryptionAlgorithm.A256CBCHS512.rawValue)
+        XCTAssertEqual(header.get(parameter: "kid") as? String, "123")
+        XCTAssertEqual(header.get(parameter: "string") as! String, "string")
+        XCTAssertEqual(header.get(parameter: "float") as! Float, Float.pi)
+        XCTAssertEqual(header.get(parameter: "double") as! Double, Double.pi)
+        XCTAssertEqual(header.get(parameter: "int") as! Int, Int.max)
+        XCTAssertEqual(header.get(parameter: "bool") as! Bool, true)
+        XCTAssertEqual(header.get(parameter: "arary") as! [String], ["one", "two", "three"])
+        XCTAssertEqual(header.get(parameter: "dict") as! [String : Int], ["one": 1, "two": 2, "three": 3])
+
+        // backing data representation is as expected
+        var expectedValue = parameterDictRSA as [String: Any]
+        expectedValue["kid"] = "123"
+        expectedValue["string"] = "string"
+        expectedValue["float"] = Float.pi
+        expectedValue["double"] = Double.pi
+        expectedValue["int"] = Int.max
+        expectedValue["bool"] = true
+        expectedValue["arary"] = ["one", "two", "three"]
+        expectedValue["dict"] = ["one": 1, "two": 2, "three": 3]
+        XCTAssertEqual(header.data(), try! JSONSerialization.data(withJSONObject: expectedValue, options: [.sortedKeys]))
+
+        // registered parameters can bre retrieved via typed computed properties
+        XCTAssertNotNil(header.keyManagementAlgorithm)
+        XCTAssertNotNil(header.contentEncryptionAlgorithm)
+        XCTAssertNotNil(header.kid)
+        XCTAssertEqual(header.keyManagementAlgorithm!, .RSA1_5)
+        XCTAssertEqual(header.contentEncryptionAlgorithm!, .A256CBCHS512)
+        XCTAssertEqual(header.kid!, "123")
+    }
+
+    func testSettingInvalidPublicPrivateHeaderParameters() throws {
+        var header = JWEHeader(keyManagementAlgorithm: .RSA1_5, contentEncryptionAlgorithm: .A256CBCHS512)
+
+        // valid parameters work
+        try header.set("123", forParameter: "kid")
+        try header.set("string", forParameter: "string")
+
+        XCTAssertEqual(header.get(parameter: "kid") as? String, "123")
+        XCTAssertEqual(header.get(parameter: "string") as! String, "string")
+
+        // invalid parameters don't work and don't interfere with valid parameters
+        XCTAssertThrowsError(try header.set("data".data(using: .utf8)!, forParameter: "data")) { error in
+            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.invalidHeaderParameterValue)
+        }
+        XCTAssertThrowsError(try header.set(UIImage.checkmark, forParameter: "image")) { error in
+            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.invalidHeaderParameterValue)
+        }
+
+        XCTAssertNil(header.get(parameter: "data"))
+        XCTAssertNil(header.get(parameter: "image"))
+        XCTAssertFalse(String(data: header.data(), encoding: .utf8)!.contains("data"))
+        XCTAssertFalse(String(data: header.data(), encoding: .utf8)!.contains("image"))
+
+        XCTAssertEqual(header.get(parameter: "kid") as? String, "123")
+        XCTAssertEqual(header.get(parameter: "string") as! String, "string")
+        XCTAssertTrue(String(data: header.data(), encoding: .utf8)!.contains("string"))
+        XCTAssertTrue(String(data: header.data(), encoding: .utf8)!.contains("kid"))
+
+
+    }
+
+    func testRemovingPublicPrivateParameters() throws {
+        var header = JWEHeader(keyManagementAlgorithm: .RSA1_5, contentEncryptionAlgorithm: .A256CBCHS512)
+
+        // setting parameters
+        try header.set("123", forParameter: "kid")
+        try header.set("string", forParameter: "string")
+
+        XCTAssertEqual(header.get(parameter: "kid") as? String, "123")
+        XCTAssertEqual(header.get(parameter: "string") as! String, "string")
+
+        // and removing them
+        header.remove(parameter: "kid")
+
+        XCTAssertNil(header.get(parameter: "kid"))
+        XCTAssertEqual(header.get(parameter: "string") as! String, "string")
+
+        // but removing required parameters doesn't work
+        XCTAssertNil(header.remove(parameter: "alg"))
+        XCTAssertNil(header.remove(parameter: "enc"))
+        XCTAssertEqual(header.keyManagementAlgorithm, .RSA1_5)
+        XCTAssertEqual(header.contentEncryptionAlgorithm, .A256CBCHS512)
+
+        XCTAssertThrowsError(try header.set("boom", forParameter: "alg")) { error in
+            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.invalidHeaderParameterValue)
+        }
+        XCTAssertThrowsError(try header.set(Optional<String>.none as Any, forParameter: "enc")) { error in
+            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.invalidHeaderParameterValue)
+        }
+        XCTAssertEqual(header.keyManagementAlgorithm, .RSA1_5)
+        XCTAssertEqual(header.contentEncryptionAlgorithm, .A256CBCHS512)
+    }
 }
 // swiftlint:enable force_unwrapping

--- a/Tests/JWSHeaderTests.swift
+++ b/Tests/JWSHeaderTests.swift
@@ -27,7 +27,7 @@ import XCTest
 
 class JWSHeaderTests: XCTestCase {
     let parameterDict = ["alg": "\(SignatureAlgorithm.RS512.rawValue)"]
-    let parameterData = try! JSONSerialization.data(withJSONObject: ["alg": "\(SignatureAlgorithm.RS512.rawValue)"], options: [])
+    let parameterData = try! JSONSerialization.data(withJSONObject: ["alg": "\(SignatureAlgorithm.RS512.rawValue)"], options: [.sortedKeys])
 
     override func setUp() {
         super.setUp()
@@ -41,11 +41,11 @@ class JWSHeaderTests: XCTestCase {
         let header = try! JWSHeader(parameters: parameterDict, headerData: parameterData)
 
         XCTAssertEqual(header.parameters["alg"] as? String, parameterDict["alg"])
-        XCTAssertEqual(header.data().count, try! JSONSerialization.data(withJSONObject: parameterDict, options: []).count)
+        XCTAssertEqual(header.data().count, parameterData.count)
     }
 
     func testInitWithData() {
-        let data = try! JSONSerialization.data(withJSONObject: parameterDict, options: [])
+        let data = parameterData
         let header = JWSHeader(data)!
 
         XCTAssertEqual(header.parameters["alg"] as? String, SignatureAlgorithm.RS512.rawValue)
@@ -55,7 +55,7 @@ class JWSHeaderTests: XCTestCase {
     func testInitWithAlg() {
         let header = JWSHeader(algorithm: .RS512)
 
-        XCTAssertEqual(header.data().count, try! JSONSerialization.data(withJSONObject: parameterDict, options: []).count)
+        XCTAssertEqual(header.data().count, parameterData.count)
         XCTAssertEqual(header.parameters["alg"] as? String, SignatureAlgorithm.RS512.rawValue)
 
         XCTAssertNotNil(header.algorithm)
@@ -64,7 +64,10 @@ class JWSHeaderTests: XCTestCase {
 
     func testInitDirectlyWithMissingRequiredParameters() {
         do {
-            _ = try JWSHeader(parameters: ["typ": "JWT"], headerData: try! JSONSerialization.data(withJSONObject: ["typ": "JWT"], options: []))
+            _ = try JWSHeader(
+                parameters: ["typ": "JWT"],
+                headerData: try! JSONSerialization.data(withJSONObject: ["typ": "JWT"], options: [.sortedKeys])
+            )
         } catch HeaderParsingError.requiredHeaderParameterMissing(let parameter) {
             XCTAssertEqual(parameter, "alg")
             return
@@ -125,7 +128,7 @@ class JWSHeaderTests: XCTestCase {
         header.cty = cty
         header.crit = crit
 
-        XCTAssertEqual(header.data().count, try! JSONSerialization.data(withJSONObject: header.parameters, options: []).count)
+        XCTAssertEqual(header.data().count, try! JSONSerialization.data(withJSONObject: header.parameters, options: [.sortedKeys]).count)
 
         XCTAssertEqual(header.parameters["jku"] as? URL, jku)
         XCTAssertEqual(header.jku, jku)

--- a/Tests/JWSHeaderTests.swift
+++ b/Tests/JWSHeaderTests.swift
@@ -258,7 +258,7 @@ class JWSHeaderTests: XCTestCase {
         XCTAssertEqual(header.get(parameter: "int") as! Int, Int.max)
         XCTAssertEqual(header.get(parameter: "bool") as! Bool, true)
         XCTAssertEqual(header.get(parameter: "arary") as! [String], ["one", "two", "three"])
-        XCTAssertEqual(header.get(parameter: "dict") as! [String : Int], ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(header.get(parameter: "dict") as! [String: Int], ["one": 1, "two": 2, "three": 3])
 
         // backing data representation is as expected
         var expectedValue = parameterDict as [String: Any]


### PR DESCRIPTION
Adds support for working with arbitrary header parameters as per [RFC-7515, 4.2/3](https://www.rfc-editor.org/rfc/rfc7515#section-4.2) (JWS) and [RFC-1716-4.2/3](https://www.rfc-editor.org/rfc/rfc7516#section-4.2) (JWE).

## Special Considerations

- This API ensures that the dictionary used to access parameters and the underlying JSON data representation stay in sync. This avoids any situations where the parameters dictionary contains a value that cannot be represented in JSON and therefore the resulting JWS/E header does not.
- It is also guaranteed that required header parameters are not removed or altered via the new API. Required header parameters must be set when initializing the JWS/E header.

## Misc

Continuing what we started in #310, this adds deterministic JSON encoding (`.sortedKeys`) to the header JSON representation.

This outdates and closes #282.