### PR TITLE
Add support for A192CBC-HS384 and A192GCM

### DIFF
--- a/JOSESwift/Sources/AESCBCEncryption.swift
+++ b/JOSESwift/Sources/AESCBCEncryption.swift
@@ -107,7 +107,7 @@ struct AESCBCEncryption {
                 return .SHA384
             case .A128CBCHS256:
                 return .SHA256
-            case .A256GCM, .A128GCM:
+            case .A256GCM, .A192GCM, .A128GCM:
                 throw JWEError.contentEncryptionAlgorithmMismatch
             }
     }
@@ -121,7 +121,7 @@ struct AESCBCEncryption {
             return (inputKey.subdata(in: 0..<24), inputKey.subdata(in: 24..<48))
         case .A128CBCHS256:
             return (inputKey.subdata(in: 0..<16), inputKey.subdata(in: 16..<32))
-        case .A256GCM, .A128GCM:
+        case .A256GCM, .A192GCM, .A128GCM:
             throw JWEError.contentEncryptionAlgorithmMismatch
         }
     }
@@ -134,7 +134,7 @@ struct AESCBCEncryption {
             return hmac.subdata(in: 0..<24)
         case .A128CBCHS256:
             return hmac.subdata(in: 0..<16)
-        case .A256GCM, .A128GCM:
+        case .A256GCM, .A192GCM, .A128GCM:
             throw JWEError.contentEncryptionAlgorithmMismatch
         }
     }

--- a/JOSESwift/Sources/AESCBCEncryption.swift
+++ b/JOSESwift/Sources/AESCBCEncryption.swift
@@ -103,6 +103,8 @@ struct AESCBCEncryption {
             switch contentEncryptionAlgorithm {
             case .A256CBCHS512:
                 return .SHA512
+            case .A192CBCHS384:
+                return .SHA384
             case .A128CBCHS256:
                 return .SHA256
             case .A256GCM, .A128GCM:
@@ -115,6 +117,8 @@ struct AESCBCEncryption {
         switch contentEncryptionAlgorithm {
         case .A256CBCHS512:
             return (inputKey.subdata(in: 0..<32), inputKey.subdata(in: 32..<64))
+        case .A192CBCHS384:
+            return (inputKey.subdata(in: 0..<24), inputKey.subdata(in: 24..<48))
         case .A128CBCHS256:
             return (inputKey.subdata(in: 0..<16), inputKey.subdata(in: 16..<32))
         case .A256GCM, .A128GCM:
@@ -126,6 +130,8 @@ struct AESCBCEncryption {
         switch contentEncryptionAlgorithm {
         case .A256CBCHS512:
             return hmac.subdata(in: 0..<32)
+        case .A192CBCHS384:
+            return hmac.subdata(in: 0..<24)
         case .A128CBCHS256:
             return hmac.subdata(in: 0..<16)
         case .A256GCM, .A128GCM:

--- a/JOSESwift/Sources/AlgorithmExtensions.swift
+++ b/JOSESwift/Sources/AlgorithmExtensions.swift
@@ -29,6 +29,8 @@ extension ContentEncryptionAlgorithm {
         switch self {
         case .A256CBCHS512:
             return 64
+        case .A192CBCHS384:
+            return 48
         case .A128CBCHS256, .A256GCM:
             return 32
         case .A128GCM:
@@ -38,7 +40,7 @@ extension ContentEncryptionAlgorithm {
 
     var initializationVectorLength: Int {
         switch self {
-        case .A128CBCHS256, .A256CBCHS512:
+        case .A128CBCHS256, .A192CBCHS384, .A256CBCHS512:
             return 16
         case .A256GCM, .A128GCM:
             return 12

--- a/JOSESwift/Sources/AlgorithmExtensions.swift
+++ b/JOSESwift/Sources/AlgorithmExtensions.swift
@@ -33,6 +33,8 @@ extension ContentEncryptionAlgorithm {
             return 48
         case .A128CBCHS256, .A256GCM:
             return 32
+        case .A192GCM:
+            return 24
         case .A128GCM:
             return 16
         }
@@ -42,7 +44,7 @@ extension ContentEncryptionAlgorithm {
         switch self {
         case .A128CBCHS256, .A192CBCHS384, .A256CBCHS512:
             return 16
-        case .A256GCM, .A128GCM:
+        case .A256GCM, .A192GCM, .A128GCM:
             return 12
         }
     }

--- a/JOSESwift/Sources/Algorithms.swift
+++ b/JOSESwift/Sources/Algorithms.swift
@@ -131,6 +131,8 @@ public enum ContentEncryptionAlgorithm: String {
     case A128CBCHS256 = "A128CBC-HS256"
     /// Content encryption using AES GCM with 256-bit key
     case A256GCM = "A256GCM"
+    /// Content encryption using AES GCM with 192-bit key
+    case A192GCM = "A192GCM"
     /// Content encryption using AES GCM with 128-bit key
     case A128GCM = "A128GCM"
 
@@ -138,6 +140,8 @@ public enum ContentEncryptionAlgorithm: String {
         switch self {
         case .A128GCM:
             return 128
+        case .A192GCM:
+            return 192
         case .A128CBCHS256, .A256GCM:
             return 256
         case .A192CBCHS384:
@@ -149,7 +153,7 @@ public enum ContentEncryptionAlgorithm: String {
 
     var tagLength: Int {
         switch self {
-        case .A128CBCHS256, .A128GCM, .A256GCM:
+        case .A128CBCHS256, .A128GCM, .A192GCM, .A256GCM:
             return 16
         case .A192CBCHS384:
             return 24

--- a/JOSESwift/Sources/Algorithms.swift
+++ b/JOSESwift/Sources/Algorithms.swift
@@ -125,6 +125,8 @@ public enum KeyManagementAlgorithm: String, CaseIterable {
 public enum ContentEncryptionAlgorithm: String {
     /// Content encryption using AES_256_CBC_HMAC_SHA_512
     case A256CBCHS512 = "A256CBC-HS512"
+    /// Content encryption using AES_192_CBC_HMAC_SHA_384
+    case A192CBCHS384 = "A192CBC-HS384"
     /// Content encryption using AES_128_CBC_HMAC_SHA_256
     case A128CBCHS256 = "A128CBC-HS256"
     /// Content encryption using AES GCM with 256-bit key
@@ -138,6 +140,8 @@ public enum ContentEncryptionAlgorithm: String {
             return 128
         case .A128CBCHS256, .A256GCM:
             return 256
+        case .A192CBCHS384:
+            return 384
         case .A256CBCHS512:
             return 512
         }
@@ -147,6 +151,8 @@ public enum ContentEncryptionAlgorithm: String {
         switch self {
         case .A128CBCHS256, .A128GCM, .A256GCM:
             return 16
+        case .A192CBCHS384:
+            return 24
         case .A256CBCHS512:
             return 32
         }

--- a/JOSESwift/Sources/ContentEncryption.swift
+++ b/JOSESwift/Sources/ContentEncryption.swift
@@ -49,7 +49,7 @@ extension ContentEncryptionAlgorithm {
         switch self {
         case .A128CBCHS256, .A192CBCHS384, .A256CBCHS512:
             return try AESCBCEncryption(contentEncryptionAlgorithm: self, secretKey: contentEncryptionKey)
-        case .A128GCM, .A256GCM:
+        case .A128GCM, .A192GCM, .A256GCM:
             return AESGCMEncryption(contentEncryptionAlgorithm: self, contentEncryptionKey: contentEncryptionKey)
         }
     }
@@ -58,7 +58,7 @@ extension ContentEncryptionAlgorithm {
         switch self {
         case .A128CBCHS256, .A192CBCHS384, .A256CBCHS512:
             return try AESCBCEncryption(contentEncryptionAlgorithm: self, secretKey: contentEncryptionKey)
-        case .A128GCM, .A256GCM:
+        case .A128GCM, .A192GCM, .A256GCM:
             return AESGCMEncryption(contentEncryptionAlgorithm: self, contentEncryptionKey: contentEncryptionKey)
         }
     }

--- a/JOSESwift/Sources/ContentEncryption.swift
+++ b/JOSESwift/Sources/ContentEncryption.swift
@@ -47,7 +47,7 @@ protocol ContentDecrypter {
 extension ContentEncryptionAlgorithm {
     func makeContentEncrypter(contentEncryptionKey: Data) throws -> ContentEncrypter {
         switch self {
-        case .A128CBCHS256, .A256CBCHS512:
+        case .A128CBCHS256, .A192CBCHS384, .A256CBCHS512:
             return try AESCBCEncryption(contentEncryptionAlgorithm: self, secretKey: contentEncryptionKey)
         case .A128GCM, .A256GCM:
             return AESGCMEncryption(contentEncryptionAlgorithm: self, contentEncryptionKey: contentEncryptionKey)
@@ -56,7 +56,7 @@ extension ContentEncryptionAlgorithm {
 
     func makeContentDecrypter(contentEncryptionKey: Data) throws -> ContentDecrypter {
         switch self {
-        case .A128CBCHS256, .A256CBCHS512:
+        case .A128CBCHS256, .A192CBCHS384, .A256CBCHS512:
             return try AESCBCEncryption(contentEncryptionAlgorithm: self, secretKey: contentEncryptionKey)
         case .A128GCM, .A256GCM:
             return AESGCMEncryption(contentEncryptionAlgorithm: self, contentEncryptionKey: contentEncryptionKey)

--- a/JOSESwift/Sources/CryptoImplementation/AES.swift
+++ b/JOSESwift/Sources/CryptoImplementation/AES.swift
@@ -37,6 +37,8 @@ fileprivate extension ContentEncryptionAlgorithm {
         switch self {
         case .A256CBCHS512:
             return CCAlgorithm(kCCAlgorithmAES)
+        case .A192CBCHS384:
+            return CCAlgorithm(kCCAlgorithmAES)
         case .A128CBCHS256:
             return CCAlgorithm(kCCAlgorithmAES)
         case .A256GCM, .A128GCM:
@@ -48,6 +50,8 @@ fileprivate extension ContentEncryptionAlgorithm {
         switch self {
         case .A256CBCHS512, .A256GCM:
             return key.count == kCCKeySizeAES256
+        case .A192CBCHS384:
+            return key.count == kCCKeySizeAES192
         case .A128CBCHS256, .A128GCM:
             return key.count == kCCKeySizeAES128
         }
@@ -101,7 +105,7 @@ enum AES {
         and initializationVector: Data
     ) throws -> Data {
         switch algorithm {
-        case .A256CBCHS512, .A128CBCHS256:
+        case .A256CBCHS512, .A192CBCHS384, .A128CBCHS256:
             guard algorithm.checkAESKeyLength(for: encryptionKey) else {
                 throw AESError.keyLengthNotSatisfied
             }
@@ -147,7 +151,7 @@ enum AES {
         and initializationVector: Data
     ) throws -> Data {
         switch algorithm {
-        case .A256CBCHS512, .A128CBCHS256:
+        case .A256CBCHS512, .A192CBCHS384, .A128CBCHS256:
             guard algorithm.checkAESKeyLength(for: decryptionKey) else {
                 throw AESError.keyLengthNotSatisfied
             }

--- a/JOSESwift/Sources/CryptoImplementation/AES.swift
+++ b/JOSESwift/Sources/CryptoImplementation/AES.swift
@@ -41,7 +41,7 @@ fileprivate extension ContentEncryptionAlgorithm {
             return CCAlgorithm(kCCAlgorithmAES)
         case .A128CBCHS256:
             return CCAlgorithm(kCCAlgorithmAES)
-        case .A256GCM, .A128GCM:
+        case .A256GCM, .A192GCM, .A128GCM:
             return nil
         }
     }
@@ -50,7 +50,7 @@ fileprivate extension ContentEncryptionAlgorithm {
         switch self {
         case .A256CBCHS512, .A256GCM:
             return key.count == kCCKeySizeAES256
-        case .A192CBCHS384:
+        case .A192CBCHS384, .A192GCM:
             return key.count == kCCKeySizeAES192
         case .A128CBCHS256, .A128GCM:
             return key.count == kCCKeySizeAES128
@@ -129,7 +129,7 @@ enum AES {
             }
 
             return ciphertext
-        case .A256GCM, .A128GCM:
+        case .A256GCM, .A192GCM, .A128GCM:
             /// This is not being used by `AESGCMEncryption` because of `KeyType` type mismatch.
             throw AESError.invalidAlgorithm
         }
@@ -175,7 +175,7 @@ enum AES {
             }
 
             return plaintext
-        case .A256GCM, .A128GCM:
+        case .A256GCM, .A192GCM, .A128GCM:
             /// This is not being used by `AESGCMEncryption` because of `KeyType` type mismatch.
             throw AESError.invalidAlgorithm
         }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you are missing a specific feature, algorithm, or serialization, feel free to
 	<tr><td><code>HS384</code></td><td>:white_check_mark:</td>                   <td><code>RSA-OAEP</code></td><td>:white_check_mark:</td>     <td><code>A192CBC-HS384</code></td><td>:white_check_mark:</td>                   <td><code>EC</code></td><td>:white_check_mark:</td></tr>
 	<tr><td><code>HS512</code></td><td>:white_check_mark:</td>                   <td><code>RSA-OAEP-256</code></td><td>:white_check_mark:</td> <td><code>A256CBC-HS512</code></td><td>:white_check_mark:</td> <td><code>oct</code></td><td>:white_check_mark:</td></tr>
 	<tr><td><code>RS256</code></td><td>:white_check_mark:</td> <td><code>A128KW</code></td><td>:white_check_mark:</td>       <td><code>A128GCM</code></td><td>:white_check_mark:</td>                         <th rowspan="14"></th><th rowspan="14"></th></tr>
-	<tr><td><code>RS384</code></td><td>:white_check_mark:</td> <td><code>A192KW</code></td><td>:white_check_mark:</td>       <td><code>A192GCM</code></td><td></td>
+	<tr><td><code>RS384</code></td><td>:white_check_mark:</td> <td><code>A192KW</code></td><td>:white_check_mark:</td>       <td><code>A192GCM</code></td><td>:white_check_mark:</td>
 	<tr><td><code>RS512</code></td><td>:white_check_mark:</td> <td><code>A256KW</code></td><td>:white_check_mark:</td>       <td><code>A256GCM</code></td><td>:white_check_mark:</td>
 	<tr><td><code>ES256</code></td><td>:white_check_mark:</td> <td><code>dir</code></td><td>:white_check_mark:</td>          <th rowspan="11"></th><th rowspan="11"></th></tr>
 	<tr><td><code>ES384</code></td><td>:white_check_mark:</td> <td><code>ECDH-ES</code></td><td>:white_check_mark:</td></tr>

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you are missing a specific feature, algorithm, or serialization, feel free to
 		<th colspan="2"><a href="https://tools.ietf.org/html/rfc7518#section-6">Keys</a></th>
 	</tr>
 	<tr><td><code>HS256</code></td><td>:white_check_mark:</td>                   <td><code>RSA1_5</code></td><td>:white_check_mark:</td>       <td><code>A128CBC-HS256</code></td><td>:white_check_mark:</td> <td><code>RSA</code></td><td>:white_check_mark:</td></tr>
-	<tr><td><code>HS384</code></td><td>:white_check_mark:</td>                   <td><code>RSA-OAEP</code></td><td>:white_check_mark:</td>     <td><code>A192CBC-HS384</code></td><td></td>                   <td><code>EC</code></td><td>:white_check_mark:</td></tr>
+	<tr><td><code>HS384</code></td><td>:white_check_mark:</td>                   <td><code>RSA-OAEP</code></td><td>:white_check_mark:</td>     <td><code>A192CBC-HS384</code></td><td>:white_check_mark:</td>                   <td><code>EC</code></td><td>:white_check_mark:</td></tr>
 	<tr><td><code>HS512</code></td><td>:white_check_mark:</td>                   <td><code>RSA-OAEP-256</code></td><td>:white_check_mark:</td> <td><code>A256CBC-HS512</code></td><td>:white_check_mark:</td> <td><code>oct</code></td><td>:white_check_mark:</td></tr>
 	<tr><td><code>RS256</code></td><td>:white_check_mark:</td> <td><code>A128KW</code></td><td>:white_check_mark:</td>       <td><code>A128GCM</code></td><td>:white_check_mark:</td>                         <th rowspan="14"></th><th rowspan="14"></th></tr>
 	<tr><td><code>RS384</code></td><td>:white_check_mark:</td> <td><code>A192KW</code></td><td>:white_check_mark:</td>       <td><code>A192GCM</code></td><td></td>

--- a/Tests/AESCBCContentDecryptionTests.swift
+++ b/Tests/AESCBCContentDecryptionTests.swift
@@ -42,6 +42,21 @@ class AESCBCContentDecryptionTests: XCTestCase {
         XCTAssertEqual(plaintext, testPlaintext)
     }
 
+    /// Tests the `AES` decryption implementation for AES_192_CBC_HMAC_SHA_384 with the test data provided in the [RFC-7518](https://tools.ietf.org/html/rfc7518#appendix-B.2).
+    func testDecryptingA192CBCHS384() {
+        let secretKey = "00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f".hexadecimalToData()!
+        let additionalAuthenticatedData = "54 68 65 20 73 65 63 6f 6e 64 20 70 72 69 6e 63 69 70 6c 65 20 6f 66 20 41 75 67 75 73 74 65 20 4b 65 72 63 6b 68 6f 66 66 73".hexadecimalToData()!
+        let iv = "1a f3 8c 2d c2 b9 6f fd d8 66 94 09 23 41 bc 04".hexadecimalToData()!
+        let ciphertext = "ea 65 da 6b 59 e6 1e db 41 9b e6 2d 19 71 2a e5 d3 03 ee b5 00 52 d0 df d6 69 7f 77 22 4c 8e db 00 0d 27 9b dc 14 c1 07 26 54 bd 30 94 42 30 c6 57 be d4 ca 0c 9f 4a 84 66 f2 2b 22 6d 17 46 21 4b f8 cf c2 40 0a dd 9f 51 26 e4 79 66 3f c9 0b 3b ed 78 7a 2f 0f fc bf 39 04 be 2a 64 1d 5c 21 05 bf e5 91 ba e2 3b 1d 74 49 e5 32 ee f6 0a 9a c8 bb 6c 6b 01 d3 5d 49 78 7b cd 57 ef 48 49 27 f2 80 ad c9 1a c0 c4 e7 9c 7b 11 ef c6 00 54 e3".hexadecimalToData()!
+        let authenticationTag = "84 90 ac 0e 58 94 9b fe 51 87 5d 73 3f 93 ac 20 75 16 80 39 cc c7 33 d7".hexadecimalToData()!
+        let testPlaintext = "41 20 63 69 70 68 65 72 20 73 79 73 74 65 6d 20 6d 75 73 74 20 6e 6f 74 20 62 65 20 72 65 71 75 69 72 65 64 20 74 6f 20 62 65 20 73 65 63 72 65 74 2c 20 61 6e 64 20 69 74 20 6d 75 73 74 20 62 65 20 61 62 6c 65 20 74 6f 20 66 61 6c 6c 20 69 6e 74 6f 20 74 68 65 20 68 61 6e 64 73 20 6f 66 20 74 68 65 20 65 6e 65 6d 79 20 77 69 74 68 6f 75 74 20 69 6e 63 6f 6e 76 65 6e 69 65 6e 63 65".hexadecimalToData()!
+
+        let decrypter = try! AESCBCEncryption(contentEncryptionAlgorithm: .A192CBCHS384, secretKey: secretKey)
+        let plaintext = try! decrypter.decrypt(ciphertext, initializationVector: iv, additionalAuthenticatedData: additionalAuthenticatedData, authenticationTag: authenticationTag)
+
+        XCTAssertEqual(plaintext, testPlaintext)
+    }
+
     /// Tests the `AES` decryption implementation for AES_128_CBC_HMAC_SHA_256 with the test data provided in the [RFC-7518](https://tools.ietf.org/html/rfc7518#appendix-B.1).
     func testDecryptingA128CBCHS256ThroughProtocolInterface() {
         let secretKey = "00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f".hexadecimalToData()!

--- a/Tests/AESCBCContentEncryptionTests.swift
+++ b/Tests/AESCBCContentEncryptionTests.swift
@@ -90,6 +90,69 @@ class AESCBCContentEncryptionTests: XCTestCase {
         XCTAssertEqual(cryptData, plaintext)
     }
 
+    /// Tests the `AES` encryption implementation for AES_192_CBC_HMAC_SHA_384 with the test data provided in the [RFC-7518](https://tools.ietf.org/html/rfc7518#appendix-B.2).
+    func testEncryptingA192CBCHS384() {
+        let plaintext = "41 20 63 69 70 68 65 72 20 73 79 73 74 65 6d 20 6d 75 73 74 20 6e 6f 74 20 62 65 20 72 65 71 75 69 72 65 64 20 74 6f 20 62 65 20 73 65 63 72 65 74 2c 20 61 6e 64 20 69 74 20 6d 75 73 74 20 62 65 20 61 62 6c 65 20 74 6f 20 66 61 6c 6c 20 69 6e 74 6f 20 74 68 65 20 68 61 6e 64 73 20 6f 66 20 74 68 65 20 65 6e 65 6d 79 20 77 69 74 68 6f 75 74 20 69 6e 63 6f 6e 76 65 6e 69 65 6e 63 65".hexadecimalToData()!
+        let additionalAuthenticatedData = "54 68 65 20 73 65 63 6f 6e 64 20 70 72 69 6e 63 69 70 6c 65 20 6f 66 20 41 75 67 75 73 74 65 20 4b 65 72 63 6b 68 6f 66 66 73".hexadecimalToData()!
+        let algorithm = ContentEncryptionAlgorithm.A192CBCHS384
+        let secretKey = try! SecureRandom.generate(count: algorithm.keyLength)
+        let encrypter = try! AESCBCEncryption(contentEncryptionAlgorithm: algorithm, secretKey: secretKey)
+        let symmetricEncryptionContext = try! encrypter.encrypt(plaintext, additionalAuthenticatedData: additionalAuthenticatedData.base64URLEncodedData())
+
+        // Check if the symmetric encryption was successful by using the CommonCrypto framework and not the implemented decrypt method.
+        let hmacKey = secretKey.subdata(in: 0..<24)
+        let encryptionKey = secretKey.subdata(in: 24..<48)
+
+        var concatData = String(data: additionalAuthenticatedData, encoding: .utf8)!.data(using: .utf8)!.base64URLEncodedData()
+        concatData.append(symmetricEncryptionContext.initializationVector)
+        concatData.append(symmetricEncryptionContext.ciphertext)
+        concatData.append(String(data: additionalAuthenticatedData, encoding: .utf8)!.data(using: .utf8)!.base64URLEncodedData().getByteLengthAsOctetHexData())
+
+        let keyLength = size_t(kCCKeySizeAES192)
+        var macOutData = Data(count: 48)
+
+        macOutData.withUnsafeMutableBytes { macOutBytes in
+            hmacKey.withUnsafeBytes { hmacKeyBytes in
+                concatData.withUnsafeBytes { concatBytes in
+                    CCHmac(CCAlgorithm(kCCHmacAlgSHA384), hmacKeyBytes.baseAddress!, keyLength, concatBytes.baseAddress!, concatData.count, macOutBytes.baseAddress!)
+                }
+            }
+        }
+
+        XCTAssertEqual(macOutData.subdata(in: 0..<24), symmetricEncryptionContext.authenticationTag)
+
+        let dataLength = symmetricEncryptionContext.ciphertext.count
+        let cryptLength  = size_t(dataLength + kCCBlockSizeAES128)
+        var cryptData = Data(count: cryptLength)
+
+        let options = CCOptions(kCCOptionPKCS7Padding)
+
+        var numBytesEncrypted: size_t = 0
+
+        let cryptStatus = cryptData.withUnsafeMutableBytes {cryptBytes in
+            symmetricEncryptionContext.ciphertext.withUnsafeBytes {dataBytes in
+                symmetricEncryptionContext.initializationVector.withUnsafeBytes {ivBytes in
+                    encryptionKey.withUnsafeBytes {keyBytes in
+                        CCCrypt(CCOperation(kCCDecrypt),
+                                CCAlgorithm(kCCAlgorithmAES128),
+                                options,
+                                keyBytes.baseAddress!, keyLength,
+                                ivBytes.baseAddress!,
+                                dataBytes.baseAddress!, dataLength,
+                                cryptBytes.baseAddress!, cryptLength,
+                                &numBytesEncrypted)
+                    }
+                }
+            }
+        }
+
+        if UInt32(cryptStatus) == UInt32(kCCSuccess) {
+            cryptData.removeSubrange(numBytesEncrypted..<cryptData.count)
+        }
+
+        XCTAssertEqual(cryptData, plaintext)
+    }
+
     /// Tests the `AES` encryption implementation for AES_256_CBC_HMAC_SHA_512 with the test data provided in the [RFC-7518](https://tools.ietf.org/html/rfc7518#appendix-B.3).
     func testEncryptingA256CBCHS512() {
         let plaintext = """

--- a/Tests/AESGCMEncryptionTests.swift
+++ b/Tests/AESGCMEncryptionTests.swift
@@ -104,7 +104,39 @@ class AESGCMEncryptionTests: XCTestCase {
     }
 
     /// Tests the `AES` decryption implementation using the header payload interface
-    func testEncrypterHeaderPayloadInterfaceEncryptsData() throws {
+    func testEncrypterHeaderPayloadInterfaceEncryptsDataA128GCM() throws {
+        let plaintext = "Live long and prosper.".data(using: .ascii)!
+        let header = JWEHeader(keyManagementAlgorithm: .RSAOAEP256, contentEncryptionAlgorithm: .A128GCM)
+        let symmetricEncryptionContext = try AESGCMEncryption(contentEncryptionAlgorithm: .A128GCM, contentEncryptionKey: contentEncryptionKey)
+            .encrypt(headerData: header.data(), payload: Payload(plaintext))
+
+        // Check if the symmetric encryption was successful by using the CryptoKit framework and not the implemented decrypt method.
+        let additionalAuthenticatedData = header.data().base64URLEncodedData()
+        let key = CryptoKit.SymmetricKey(data: contentEncryptionKey)
+        let nonce = try CryptoKit.AES.GCM.Nonce(data: symmetricEncryptionContext.initializationVector)
+        let encrypted = try CryptoKit.AES.GCM.SealedBox(nonce: nonce, ciphertext: symmetricEncryptionContext.ciphertext, tag: symmetricEncryptionContext.authenticationTag)
+        let decrypted = try CryptoKit.AES.GCM.open(encrypted, using: key, authenticating: additionalAuthenticatedData)
+        XCTAssertEqual(decrypted, plaintext)
+    }
+
+    /// Tests the `AES` decryption implementation using the header payload interface
+    func testEncrypterHeaderPayloadInterfaceEncryptsDataA192GCM() throws {
+        let plaintext = "Live long and prosper.".data(using: .ascii)!
+        let header = JWEHeader(keyManagementAlgorithm: .RSAOAEP256, contentEncryptionAlgorithm: .A192GCM)
+        let symmetricEncryptionContext = try AESGCMEncryption(contentEncryptionAlgorithm: .A192GCM, contentEncryptionKey: contentEncryptionKey)
+            .encrypt(headerData: header.data(), payload: Payload(plaintext))
+
+        // Check if the symmetric encryption was successful by using the CryptoKit framework and not the implemented decrypt method.
+        let additionalAuthenticatedData = header.data().base64URLEncodedData()
+        let key = CryptoKit.SymmetricKey(data: contentEncryptionKey)
+        let nonce = try CryptoKit.AES.GCM.Nonce(data: symmetricEncryptionContext.initializationVector)
+        let encrypted = try CryptoKit.AES.GCM.SealedBox(nonce: nonce, ciphertext: symmetricEncryptionContext.ciphertext, tag: symmetricEncryptionContext.authenticationTag)
+        let decrypted = try CryptoKit.AES.GCM.open(encrypted, using: key, authenticating: additionalAuthenticatedData)
+        XCTAssertEqual(decrypted, plaintext)
+    }
+
+    /// Tests the `AES` decryption implementation using the header payload interface
+    func testEncrypterHeaderPayloadInterfaceEncryptsDataA256GCM() throws {
         let plaintext = "Live long and prosper.".data(using: .ascii)!
         let header = JWEHeader(keyManagementAlgorithm: .RSAOAEP256, contentEncryptionAlgorithm: .A256GCM)
         let symmetricEncryptionContext = try AESGCMEncryption(contentEncryptionAlgorithm: .A256GCM, contentEncryptionKey: contentEncryptionKey)
@@ -122,8 +154,11 @@ class AESGCMEncryptionTests: XCTestCase {
     func testContentEncryptionAlgorithmFeatures() {
         // verify key length
         XCTAssertEqual(32, ContentEncryptionAlgorithm.A256GCM.keyLength)
+        XCTAssertEqual(24, ContentEncryptionAlgorithm.A192GCM.keyLength)
         XCTAssertEqual(16, ContentEncryptionAlgorithm.A128GCM.keyLength)
         // verify iv length
+        XCTAssertEqual(12, ContentEncryptionAlgorithm.A128GCM.initializationVectorLength)
+        XCTAssertEqual(12, ContentEncryptionAlgorithm.A192GCM.initializationVectorLength)
         XCTAssertEqual(12, ContentEncryptionAlgorithm.A256GCM.initializationVectorLength)
         // verify non supported content encryption algorithm throws error upon initialization
         XCTAssertThrowsError(try AESCBCEncryption(contentEncryptionAlgorithm: ContentEncryptionAlgorithm.A256GCM, secretKey: contentEncryptionKey)) { error in


### PR DESCRIPTION
_🍇 Some low hanging fruits:_ Adds support for [A192CBC-HS384](https://datatracker.ietf.org/doc/html/rfc7518#section-5.2.4) and [A192GCM](https://datatracker.ietf.org/doc/html/rfc7518#section-5.3).

After this, the only algorithms still missing are the A*GCMKW variants. 🎉 

<img width="887" alt="Screenshot 2024-08-23 at 20 29 37" src="https://github.com/user-attachments/assets/4e6ee9fb-47ca-4141-8653-ed06f78e4042">
