### PR TITLE
Allow for plugging in user-provided crypto implementations via customization API

### DIFF
--- a/JOSESwift.xcodeproj/project.pbxproj
+++ b/JOSESwift.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		65D868111F7CEBA200769BBF /* Verifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D868101F7CEBA200769BBF /* Verifier.swift */; };
 		65D8E8E820F499EF0059506A /* SymmetricKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D8E8E720F499EF0059506A /* SymmetricKeys.swift */; };
 		65D8E8EA20F4AF880059506A /* SymmetricKeyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D8E8E920F4AF880059506A /* SymmetricKeyCodable.swift */; };
+		65E0346D2C7C6AA000C1E706 /* JWSCustomSignerVerifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E0346C2C7C6AA000C1E706 /* JWSCustomSignerVerifierTests.swift */; };
 		65E733CC1FEBE8320009EAC6 /* JWKExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E733CB1FEBE8320009EAC6 /* JWKExtensions.swift */; };
 		65E733D11FEBF7960009EAC6 /* JWKParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E733D01FEBF7960009EAC6 /* JWKParameters.swift */; };
 		65E733D31FEBFDB30009EAC6 /* JWKtoJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E733D21FEBFDB30009EAC6 /* JWKtoJSONTests.swift */; };
@@ -236,6 +237,7 @@
 		65D868101F7CEBA200769BBF /* Verifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Verifier.swift; sourceTree = "<group>"; };
 		65D8E8E720F499EF0059506A /* SymmetricKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymmetricKeys.swift; sourceTree = "<group>"; };
 		65D8E8E920F4AF880059506A /* SymmetricKeyCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymmetricKeyCodable.swift; sourceTree = "<group>"; };
+		65E0346C2C7C6AA000C1E706 /* JWSCustomSignerVerifierTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JWSCustomSignerVerifierTests.swift; sourceTree = "<group>"; };
 		65E733CB1FEBE8320009EAC6 /* JWKExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWKExtensions.swift; sourceTree = "<group>"; };
 		65E733D01FEBF7960009EAC6 /* JWKParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWKParameters.swift; sourceTree = "<group>"; };
 		65E733D21FEBFDB30009EAC6 /* JWKtoJSONTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWKtoJSONTests.swift; sourceTree = "<group>"; };
@@ -313,6 +315,7 @@
 			children = (
 				9665A24622B0F3E100EAC14A /* ECAsn1IntegerConversionTests.swift */,
 				6575696C203EF9CE004A0EFD /* JWSValidationTests.swift */,
+				65E0346C2C7C6AA000C1E706 /* JWSCustomSignerVerifierTests.swift */,
 				652C61391FD99A3300578E2A /* JWSSigningInputTest.swift */,
 				C803EFE81FA7893A00B71335 /* JWSHeaderTests.swift */,
 				C803EFE41FA77E3000B71335 /* JWSRSATests.swift */,
@@ -779,6 +782,7 @@
 				656A3F482C78EE2E00071779 /* PBES2KeyEncryptionModeTests.swift in Sources */,
 				C803EFE91FA7893A00B71335 /* JWSHeaderTests.swift in Sources */,
 				652C613A1FD99A3300578E2A /* JWSSigningInputTest.swift in Sources */,
+				65E0346D2C7C6AA000C1E706 /* JWSCustomSignerVerifierTests.swift in Sources */,
 				C8A592401FC71586009CEFA6 /* RSADecryptionTests.swift in Sources */,
 				C803EFF31FA8A98F00B71335 /* DataExtensionTests.swift in Sources */,
 				653656072035D6C700A3AC3B /* JWKSetCollectionTests.swift in Sources */,

--- a/JOSESwift.xcodeproj/project.pbxproj
+++ b/JOSESwift.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		6582614F2029F2D100B594ED /* ASN1DERParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6582614E2029F2D100B594ED /* ASN1DERParsing.swift */; };
 		65826AB22028696000AFFC46 /* RSAKeyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65826AB12028696000AFFC46 /* RSAKeyCodable.swift */; };
 		65826AB420286B3A00AFFC46 /* JWKRSAEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65826AB320286B3A00AFFC46 /* JWKRSAEncodingTests.swift */; };
+		65869D442C7CE34700918E8B /* JWSCustomEncrypterDecrypterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65869D432C7CE34700918E8B /* JWSCustomEncrypterDecrypterTests.swift */; };
 		658EE1AF23F4067D00B6E967 /* AlgorithmExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658EE1AE23F4067D00B6E967 /* AlgorithmExtensions.swift */; };
 		65A103A1202B03BB00D22BF5 /* ASN1DERParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A103A0202B03BB00D22BF5 /* ASN1DERParsingTests.swift */; };
 		65A103A3202B0CDF00D22BF5 /* DataRSAPublicKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A103A2202B0CDF00D22BF5 /* DataRSAPublicKeyTests.swift */; };
@@ -221,6 +222,7 @@
 		6582614E2029F2D100B594ED /* ASN1DERParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASN1DERParsing.swift; sourceTree = "<group>"; };
 		65826AB12028696000AFFC46 /* RSAKeyCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSAKeyCodable.swift; sourceTree = "<group>"; };
 		65826AB320286B3A00AFFC46 /* JWKRSAEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWKRSAEncodingTests.swift; sourceTree = "<group>"; };
+		65869D432C7CE34700918E8B /* JWSCustomEncrypterDecrypterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JWSCustomEncrypterDecrypterTests.swift; sourceTree = "<group>"; };
 		658EE1AE23F4067D00B6E967 /* AlgorithmExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlgorithmExtensions.swift; sourceTree = "<group>"; };
 		65A103A0202B03BB00D22BF5 /* ASN1DERParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASN1DERParsingTests.swift; sourceTree = "<group>"; };
 		65A103A2202B0CDF00D22BF5 /* DataRSAPublicKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataRSAPublicKeyTests.swift; sourceTree = "<group>"; };
@@ -329,6 +331,7 @@
 		65125A2E1FBF6B9E007CF3AE /* JWE */ = {
 			isa = PBXGroup;
 			children = (
+				65869D432C7CE34700918E8B /* JWSCustomEncrypterDecrypterTests.swift */,
 				8A30B8F922118FE6001834E3 /* JWECompressionTests.swift */,
 				65676D8A1FC220C70031B26D /* JWEDeserializationTests.swift */,
 				C803EFEC1FA8849C00B71335 /* JWERSATests.swift */,
@@ -782,6 +785,7 @@
 				656A3F482C78EE2E00071779 /* PBES2KeyEncryptionModeTests.swift in Sources */,
 				C803EFE91FA7893A00B71335 /* JWSHeaderTests.swift in Sources */,
 				652C613A1FD99A3300578E2A /* JWSSigningInputTest.swift in Sources */,
+				65869D442C7CE34700918E8B /* JWSCustomEncrypterDecrypterTests.swift in Sources */,
 				65E0346D2C7C6AA000C1E706 /* JWSCustomSignerVerifierTests.swift in Sources */,
 				C8A592401FC71586009CEFA6 /* RSADecryptionTests.swift in Sources */,
 				C803EFF31FA8A98F00B71335 /* DataExtensionTests.swift in Sources */,

--- a/JOSESwift/Sources/AESKeyWrappingMode.swift
+++ b/JOSESwift/Sources/AESKeyWrappingMode.swift
@@ -66,7 +66,7 @@ extension AESKeyWrappingMode: EncryptionKeyManagementMode {
 }
 
 extension AESKeyWrappingMode: DecryptionKeyManagementMode {
-    func determineContentEncryptionKey(from encryptedKey: Data) throws -> Data {
+    func determineContentEncryptionKey(from encryptedKey: Data, with _: JWEHeader) throws -> Data {
         let contentEncryptionKey = try AES.unwrap(
             wrappedKey: encryptedKey,
             keyEncryptionKey: sharedSymmetricKey,

--- a/JOSESwift/Sources/AESKeyWrappingMode.swift
+++ b/JOSESwift/Sources/AESKeyWrappingMode.swift
@@ -44,7 +44,11 @@ struct AESKeyWrappingMode {
 }
 
 extension AESKeyWrappingMode: EncryptionKeyManagementMode {
-    func determineContentEncryptionKey() throws -> (contentEncryptionKey: Data, encryptedKey: Data) {
+    var algorithm: KeyManagementAlgorithm {
+        keyManagementAlgorithm
+    }
+    
+    func determineContentEncryptionKey(with _: JWEHeader) throws -> KeyManagementContext {
         let contentEncryptionKey = try SecureRandom.generate(count: contentEncryptionAlgorithm.keyLength)
 
         let encryptedKey = try AES.wrap(
@@ -53,7 +57,11 @@ extension AESKeyWrappingMode: EncryptionKeyManagementMode {
             algorithm: keyManagementAlgorithm
         )
 
-        return (contentEncryptionKey, encryptedKey)
+        return KeyManagementContext(
+            contentEncryptionKey: contentEncryptionKey,
+            encryptedKey: encryptedKey,
+            jweHeader: nil
+        )
     }
 }
 

--- a/JOSESwift/Sources/AESKeyWrappingMode.swift
+++ b/JOSESwift/Sources/AESKeyWrappingMode.swift
@@ -47,8 +47,8 @@ extension AESKeyWrappingMode: EncryptionKeyManagementMode {
     var algorithm: KeyManagementAlgorithm {
         keyManagementAlgorithm
     }
-    
-    func determineContentEncryptionKey(with _: JWEHeader) throws -> KeyManagementContext {
+
+    func determineContentEncryptionKey(with _: JWEHeader) throws -> EncryptionKeyManagementModeContext {
         let contentEncryptionKey = try SecureRandom.generate(count: contentEncryptionAlgorithm.keyLength)
 
         let encryptedKey = try AES.wrap(
@@ -57,7 +57,7 @@ extension AESKeyWrappingMode: EncryptionKeyManagementMode {
             algorithm: keyManagementAlgorithm
         )
 
-        return KeyManagementContext(
+        return .init(
             contentEncryptionKey: contentEncryptionKey,
             encryptedKey: encryptedKey,
             jweHeader: nil

--- a/JOSESwift/Sources/ContentEncryption.swift
+++ b/JOSESwift/Sources/ContentEncryption.swift
@@ -23,43 +23,48 @@
 
 import Foundation
 
-struct ContentEncryptionContext {
+public protocol ContentEncrypter {
+    var algorithm: ContentEncryptionAlgorithm { get }
+
+    func encrypt(headerData: Data, payload: Payload, contentEncryptionKey: Data) throws -> ContentEncryptionContext
+}
+
+public protocol ContentDecrypter {
+    var algorithm: ContentEncryptionAlgorithm { get }
+
+    func decrypt(decryptionContext: ContentDecryptionContext) throws -> Data
+}
+
+public struct ContentEncryptionContext {
     let ciphertext: Data
     let authenticationTag: Data
     let initializationVector: Data
 }
 
-struct ContentDecryptionContext {
+public struct ContentDecryptionContext {
     let ciphertext: Data
     let initializationVector: Data
     let additionalAuthenticatedData: Data
     let authenticationTag: Data
-}
-
-protocol ContentEncrypter {
-    func encrypt(headerData: Data, payload: Payload) throws -> ContentEncryptionContext
-}
-
-protocol ContentDecrypter {
-    func decrypt(decryptionContext: ContentDecryptionContext) throws -> Data
+    let contentEncryptionKey: Data
 }
 
 extension ContentEncryptionAlgorithm {
-    func makeContentEncrypter(contentEncryptionKey: Data) throws -> ContentEncrypter {
+    func makeContentEncrypter() throws -> ContentEncrypter {
         switch self {
         case .A128CBCHS256, .A192CBCHS384, .A256CBCHS512:
-            return try AESCBCEncryption(contentEncryptionAlgorithm: self, secretKey: contentEncryptionKey)
+            return try AESCBCEncryption(contentEncryptionAlgorithm: self)
         case .A128GCM, .A192GCM, .A256GCM:
-            return AESGCMEncryption(contentEncryptionAlgorithm: self, contentEncryptionKey: contentEncryptionKey)
+            return AESGCMEncryption(contentEncryptionAlgorithm: self)
         }
     }
 
-    func makeContentDecrypter(contentEncryptionKey: Data) throws -> ContentDecrypter {
+    func makeContentDecrypter() throws -> ContentDecrypter {
         switch self {
         case .A128CBCHS256, .A192CBCHS384, .A256CBCHS512:
-            return try AESCBCEncryption(contentEncryptionAlgorithm: self, secretKey: contentEncryptionKey)
+            return try AESCBCEncryption(contentEncryptionAlgorithm: self)
         case .A128GCM, .A192GCM, .A256GCM:
-            return AESGCMEncryption(contentEncryptionAlgorithm: self, contentEncryptionKey: contentEncryptionKey)
+            return AESGCMEncryption(contentEncryptionAlgorithm: self)
         }
     }
 }

--- a/JOSESwift/Sources/CryptoImplementation/EC.swift
+++ b/JOSESwift/Sources/CryptoImplementation/EC.swift
@@ -292,7 +292,7 @@ internal struct EC {
                                      encryption: ContentEncryptionAlgorithm,
                                      header: JWEHeader,
                                      options: [String: Any] = [:]
-    ) throws -> Data {
+    ) throws -> (contentEncryptionKey: Data, encryptedKey: Data, jweHeaderData: Data) {
         var ephemeralKeyPair: ECKeyPair
         if let eKeyPair = options["ephemeralKeyPair"] as? ECKeyPair {
             ephemeralKeyPair = eKeyPair
@@ -328,11 +328,7 @@ internal struct EC {
             updatedHeader.epk = ephemeralKeyPair.getPublic()
         }
 
-        let context = Encrypter.ECEncryptionContext(headerData: updatedHeader.headerData,
-                                                    encryptedKey: encryptedKey,
-                                                    contentKey: contentKey)
-        let result = try JSONEncoder().encode(context)
-        return result
+        return (contentEncryptionKey: contentKey, encryptedKey: encryptedKey, jweHeaderData: updatedHeader.headerData)
     }
 
     /// Decrypts a cipher text using a given `EC` algorithm and the corresponding private key.

--- a/JOSESwift/Sources/Decrypter.swift
+++ b/JOSESwift/Sources/Decrypter.swift
@@ -55,6 +55,14 @@ public struct Decrypter {
         self.contentDecrypter = contentDecrypter
     }
 
+    /// Constructs an decrypter used to decrypt a JWE.
+    ///
+    /// - Parameters:
+    ///   - keyManagementMode: A custom key management implementation.
+    ///   - contentEncrypter: A custom content decryption implementation.
+    ///
+    ///   It is the implementors responsibility to ensure compliance with the necessary specifications.
+    /// - Returns: A fully initialized `Decrypter`.
     public init(
         customKeyManagementMode keyManagementMode: DecryptionKeyManagementMode,
         customContentDecrypter contentDecrypter: ContentDecrypter

--- a/JOSESwift/Sources/DirectEncryptionMode.swift
+++ b/JOSESwift/Sources/DirectEncryptionMode.swift
@@ -41,9 +41,9 @@ extension DirectEncryptionMode: EncryptionKeyManagementMode {
     var algorithm: KeyManagementAlgorithm {
         keyManagementAlgorithm
     }
-    
-    func determineContentEncryptionKey(with _: JWEHeader) throws -> KeyManagementContext {
-        return KeyManagementContext(contentEncryptionKey: sharedSymmetricKey, encryptedKey: KeyType(), jweHeader: nil)
+
+    func determineContentEncryptionKey(with _: JWEHeader) throws -> EncryptionKeyManagementModeContext {
+        return .init(contentEncryptionKey: sharedSymmetricKey, encryptedKey: KeyType(), jweHeader: nil)
     }
 }
 

--- a/JOSESwift/Sources/DirectEncryptionMode.swift
+++ b/JOSESwift/Sources/DirectEncryptionMode.swift
@@ -28,16 +28,22 @@ import Foundation
 struct DirectEncryptionMode {
     typealias KeyType = Data
 
+    private let keyManagementAlgorithm: KeyManagementAlgorithm
     private let sharedSymmetricKey: KeyType
 
-    init(sharedSymmetricKey: KeyType) {
+    init(keyManagementAlgorithm: KeyManagementAlgorithm, sharedSymmetricKey: KeyType) {
+        self.keyManagementAlgorithm = keyManagementAlgorithm
         self.sharedSymmetricKey = sharedSymmetricKey
     }
 }
 
 extension DirectEncryptionMode: EncryptionKeyManagementMode {
-    func determineContentEncryptionKey() throws -> (contentEncryptionKey: Data, encryptedKey: Data) {
-        return (sharedSymmetricKey, KeyType())
+    var algorithm: KeyManagementAlgorithm {
+        keyManagementAlgorithm
+    }
+    
+    func determineContentEncryptionKey(with _: JWEHeader) throws -> KeyManagementContext {
+        return KeyManagementContext(contentEncryptionKey: sharedSymmetricKey, encryptedKey: KeyType(), jweHeader: nil)
     }
 }
 

--- a/JOSESwift/Sources/DirectEncryptionMode.swift
+++ b/JOSESwift/Sources/DirectEncryptionMode.swift
@@ -48,7 +48,7 @@ extension DirectEncryptionMode: EncryptionKeyManagementMode {
 }
 
 extension DirectEncryptionMode: DecryptionKeyManagementMode {
-    func determineContentEncryptionKey(from encryptedKey: Data) throws -> Data {
+    func determineContentEncryptionKey(from encryptedKey: Data, with _: JWEHeader) throws -> Data {
         guard encryptedKey == Data() else {
             throw JOSESwiftError.decryptingFailed(description: "Direct encryption does not expect an encrypted key.")
         }

--- a/JOSESwift/Sources/ECKeyEncryption.swift
+++ b/JOSESwift/Sources/ECKeyEncryption.swift
@@ -68,7 +68,7 @@ extension ECKeyEncryption.EncryptionMode: EncryptionKeyManagementMode {
                                            options: options)
 
         guard let updatedJweHeader = JWEHeader(ecEncryption.jweHeaderData) else {
-            throw ECError.wrapKeyFail // todo: better error type?
+            throw ECError.wrapKeyFail
 
         }
 

--- a/JOSESwift/Sources/ECKeyEncryption.swift
+++ b/JOSESwift/Sources/ECKeyEncryption.swift
@@ -59,7 +59,7 @@ extension ECKeyEncryption.EncryptionMode: EncryptionKeyManagementMode {
     var algorithm: KeyManagementAlgorithm {
         keyManagementAlgorithm
     }
-    
+
     func determineContentEncryptionKey(with jweHeader: JWEHeader) throws -> KeyManagementContext {
         let ecEncryption = try EC.encryptionContextFor(recipientPublicKey,
                                            algorithm: keyManagementAlgorithm,
@@ -81,7 +81,11 @@ extension ECKeyEncryption.EncryptionMode: EncryptionKeyManagementMode {
 }
 
 extension ECKeyEncryption.DecryptionMode: DecryptionKeyManagementMode {
-    func determineContentEncryptionKey(from encryptedKey: Data, header: JWEHeader) throws -> Data {
+    var algorithm: KeyManagementAlgorithm {
+        keyManagementAlgorithm
+    }
+
+    func determineContentEncryptionKey(from encryptedKey: Data, with header: JWEHeader) throws -> Data {
 
         let randomContentEncryptionKey = try SecureRandom.generate(count: contentEncryptionAlgorithm.keyLength)
 
@@ -92,6 +96,7 @@ extension ECKeyEncryption.DecryptionMode: DecryptionKeyManagementMode {
                                            header: header)
 
         guard decryptedKey.count == contentEncryptionAlgorithm.keyLength else { return randomContentEncryptionKey }
+
         return decryptedKey
     }
 }

--- a/JOSESwift/Sources/ECKeyEncryption.swift
+++ b/JOSESwift/Sources/ECKeyEncryption.swift
@@ -60,7 +60,7 @@ extension ECKeyEncryption.EncryptionMode: EncryptionKeyManagementMode {
         keyManagementAlgorithm
     }
 
-    func determineContentEncryptionKey(with jweHeader: JWEHeader) throws -> KeyManagementContext {
+    func determineContentEncryptionKey(with jweHeader: JWEHeader) throws -> EncryptionKeyManagementModeContext {
         let ecEncryption = try EC.encryptionContextFor(recipientPublicKey,
                                            algorithm: keyManagementAlgorithm,
                                            encryption: contentEncryptionAlgorithm,
@@ -72,7 +72,7 @@ extension ECKeyEncryption.EncryptionMode: EncryptionKeyManagementMode {
 
         }
 
-        return KeyManagementContext(
+        return .init(
             contentEncryptionKey: ecEncryption.contentEncryptionKey,
             encryptedKey: ecEncryption.encryptedKey,
             jweHeader: updatedJweHeader

--- a/JOSESwift/Sources/Encrypter.swift
+++ b/JOSESwift/Sources/Encrypter.swift
@@ -61,6 +61,14 @@ public struct Encrypter {
         self.contentEncryper = contentEncrypter
     }
 
+    /// Constructs an encrypter used to encrypt a JWE.
+    ///
+    /// - Parameters:
+    ///   - keyManagementMode: A custom key management implementation.
+    ///   - contentEncrypter: A custom content encryption implementation.
+    ///
+    ///   It is the implementors responsibility to ensure compliance with the necessary specifications.
+    /// - Returns: A fully initialized `Encrypter`.
     public init(
         customKeyManagementMode keyManagementMode: EncryptionKeyManagementMode,
         customContentEncrypter contentEncrypter: ContentEncrypter

--- a/JOSESwift/Sources/Encrypter.swift
+++ b/JOSESwift/Sources/Encrypter.swift
@@ -67,7 +67,7 @@ public struct Encrypter {
     }
 
     internal func encrypt(header: inout JWEHeader, payload: Payload) throws -> EncryptionContext {
-        guard let alg = header.keyManagementAlgorithm, alg == keyManagementMode.algorithm else {
+        guard let headerAlg = header.keyManagementAlgorithm, headerAlg == keyManagementMode.algorithm else {
             throw JWEError.keyManagementAlgorithmMismatch
         }
 

--- a/JOSESwift/Sources/JOSESwiftError.swift
+++ b/JOSESwift/Sources/JOSESwiftError.swift
@@ -66,4 +66,8 @@ public enum JOSESwiftError: Error {
 
     // Header errors
     case invalidHeaderParameterValue
+
+    case keyManagementAlrgorithmMismatch
+    case contentEncryptionAlgorithmMismatch
+    case signingAlgorithmMismatch
 }

--- a/JOSESwift/Sources/JWE.swift
+++ b/JOSESwift/Sources/JWE.swift
@@ -194,7 +194,7 @@ public struct JWE {
         } catch JWEError.keyManagementAlgorithmMismatch {
             // todo: better error type?
             throw JOSESwiftError.decryptingFailed(description: "JWE header algorithms do not match encrypter algorithms.")
-        }  catch JWEError.contentEncryptionAlgorithmMismatch {
+        } catch JWEError.contentEncryptionAlgorithmMismatch {
             // todo: better error type?
             throw JOSESwiftError.decryptingFailed(description: "JWE header algorithms do not match encrypter algorithms.")
         } catch JOSESwiftError.decompressionFailed {

--- a/JOSESwift/Sources/JWE.swift
+++ b/JOSESwift/Sources/JWE.swift
@@ -191,11 +191,10 @@ public struct JWE {
             let decryptedData = try decrypter.decrypt(context)
             return Payload(try compressor.decompress(data: decryptedData))
         } catch JWEError.keyManagementAlgorithmMismatch {
-            // todo: better error type?
-            throw JOSESwiftError.decryptingFailed(description: "JWE header algorithms do not match encrypter algorithms.")
+            throw JOSESwiftError.keyManagementAlrgorithmMismatch
         } catch JWEError.contentEncryptionAlgorithmMismatch {
             // todo: better error type?
-            throw JOSESwiftError.decryptingFailed(description: "JWE header algorithms do not match encrypter algorithms.")
+            throw JOSESwiftError.contentEncryptionAlgorithmMismatch
         } catch JOSESwiftError.decompressionFailed {
             throw JOSESwiftError.decompressionFailed
         } catch JOSESwiftError.compressionAlgorithmNotSupported {

--- a/JOSESwift/Sources/JWE.swift
+++ b/JOSESwift/Sources/JWE.swift
@@ -37,7 +37,7 @@ internal enum JWEError: Error {
 /// As discussed, it is the responsibility of the framework user to cache e.g. the plaintext. Of course this will have to be communicated clearly.
 public struct JWE {
     /// The JWE's JOSE Header.
-    public var header: JWEHeader
+    public let header: JWEHeader
 
     /// The encrypted content encryption key (CEK).
     public let encryptedKey: Data
@@ -71,11 +71,9 @@ public struct JWE {
     ///   - encrypter: The `Encrypter` used to encrypt the JWE from the header and payload.
     /// - Throws: `JOSESwiftError` if any error occurs while encrypting.
     public init(header: JWEHeader, payload: Payload, encrypter: Encrypter) throws {
-        self.header = header
-
         var encryptionContext: Encrypter.EncryptionContext
         do {
-            encryptionContext = try encrypter.encrypt(header: &self.header, payload: payload.compressed(using: header.compressionAlgorithm))
+            encryptionContext = try encrypter.encrypt(header: header, payload: payload.compressed(using: header.compressionAlgorithm))
         } catch JOSESwiftError.compressionFailed {
             throw JOSESwiftError.compressionFailed
         } catch JOSESwiftError.compressionAlgorithmNotSupported {
@@ -84,6 +82,7 @@ public struct JWE {
             throw JOSESwiftError.encryptingFailed(description: error.localizedDescription)
         }
 
+        self.header = encryptionContext.jweHeader
         self.encryptedKey = encryptionContext.encryptedKey
         self.ciphertext = encryptionContext.ciphertext
         self.initializationVector = encryptionContext.initializationVector

--- a/JOSESwift/Sources/JWE.swift
+++ b/JOSESwift/Sources/JWE.swift
@@ -187,17 +187,16 @@ public struct JWE {
             authenticationTag: authenticationTag
         )
 
-        guard
-            decrypter.keyManagementAlgorithm == header.keyManagementAlgorithm,
-            decrypter.contentEncryptionAlgorithm == header.contentEncryptionAlgorithm
-        else {
-            throw JOSESwiftError.decryptingFailed(description: "JWE header algorithms do not match encrypter algorithms.")
-        }
-
         do {
             let compressor = try CompressorFactory.makeCompressor(algorithm: header.compressionAlgorithm)
             let decryptedData = try decrypter.decrypt(context)
             return Payload(try compressor.decompress(data: decryptedData))
+        } catch JWEError.keyManagementAlgorithmMismatch {
+            // todo: better error type?
+            throw JOSESwiftError.decryptingFailed(description: "JWE header algorithms do not match encrypter algorithms.")
+        }  catch JWEError.contentEncryptionAlgorithmMismatch {
+            // todo: better error type?
+            throw JOSESwiftError.decryptingFailed(description: "JWE header algorithms do not match encrypter algorithms.")
         } catch JOSESwiftError.decompressionFailed {
             throw JOSESwiftError.decompressionFailed
         } catch JOSESwiftError.compressionAlgorithmNotSupported {

--- a/JOSESwift/Sources/JWE.swift
+++ b/JOSESwift/Sources/JWE.swift
@@ -193,7 +193,6 @@ public struct JWE {
         } catch JWEError.keyManagementAlgorithmMismatch {
             throw JOSESwiftError.keyManagementAlrgorithmMismatch
         } catch JWEError.contentEncryptionAlgorithmMismatch {
-            // todo: better error type?
             throw JOSESwiftError.contentEncryptionAlgorithmMismatch
         } catch JOSESwiftError.decompressionFailed {
             throw JOSESwiftError.decompressionFailed

--- a/JOSESwift/Sources/JWS.swift
+++ b/JOSESwift/Sources/JWS.swift
@@ -146,7 +146,7 @@ public struct JWS {
     @available(*, deprecated, message: "Use `validate(using verifier:)` instead")
     public func validate<KeyType>(with publicKey: KeyType) throws -> JWS {
         guard let alg = header.algorithm else {
-            throw JOSESwiftError.verifyingFailed(description: "Invalid header parameter.")
+            throw JOSESwiftError.signingAlgorithmMismatch
         }
 
         guard let verifier = Verifier(verifyingAlgorithm: alg, publicKey: publicKey) else {
@@ -170,14 +170,12 @@ public struct JWS {
     /// - Returns: The JWS on which this function was called if the signature is valid.
     /// - Throws: A `JOSESwiftError` if the signature is invalid or if errors occured during signature validation.
     public func validate(using verifier: Verifier) throws -> JWS {
-        guard verifier.verifier.algorithm == header.algorithm else {
-            throw JOSESwiftError.verifyingFailed(description: "JWS header algorithm does not match verifier algorithm.")
-        }
-
         do {
             guard try verifier.verify(header: header, and: payload, against: signature) else {
                 throw JOSESwiftError.signatureInvalid
             }
+        } catch JWSError.algorithmMismatch {
+            throw JOSESwiftError.signingAlgorithmMismatch
         } catch {
             throw JOSESwiftError.verifyingFailed(description: error.localizedDescription)
         }

--- a/JOSESwift/Sources/JWS.swift
+++ b/JOSESwift/Sources/JWS.swift
@@ -54,7 +54,7 @@ public struct JWS {
     ///   - payload: A fully initialized `Payload`.
     ///   - signer: The `Signer` used to compute the JWS signature from the header and payload.
     /// - Throws: `JOSESwiftError` if any error occurs while signing. 
-    public init<KeyType>(header: JWSHeader, payload: Payload, signer: Signer<KeyType>) throws {
+    public init(header: JWSHeader, payload: Payload, signer: Signer) throws {
         self.header = header
         self.payload = payload
 

--- a/JOSESwift/Sources/KeyManagementMode.swift
+++ b/JOSESwift/Sources/KeyManagementMode.swift
@@ -26,11 +26,10 @@ import Foundation
 public protocol EncryptionKeyManagementMode {
     var algorithm: KeyManagementAlgorithm { get }
 
-    func determineContentEncryptionKey(with header: JWEHeader) throws -> KeyManagementContext
+    func determineContentEncryptionKey(with header: JWEHeader) throws -> EncryptionKeyManagementModeContext
 }
 
-// todo: rename to EncryptionKeyManagementContext
-public struct KeyManagementContext {
+public struct EncryptionKeyManagementModeContext {
     let contentEncryptionKey: Data
     let encryptedKey: Data
     let jweHeader: JWEHeader?

--- a/JOSESwift/Sources/KeyManagementMode.swift
+++ b/JOSESwift/Sources/KeyManagementMode.swift
@@ -25,24 +25,21 @@ import Foundation
 
 public protocol EncryptionKeyManagementMode {
     var algorithm: KeyManagementAlgorithm { get }
-    
+
     func determineContentEncryptionKey(with header: JWEHeader) throws -> KeyManagementContext
 }
 
-protocol DecryptionKeyManagementMode {
-    func determineContentEncryptionKey(from encryptedKey: Data) throws -> Data
-    func determineContentEncryptionKey(from encryptedKey: Data, header: JWEHeader) throws -> Data
-}
-
-extension DecryptionKeyManagementMode {
-    func determineContentEncryptionKey(from encryptedKey: Data) throws -> Data { return Data() }
-    func determineContentEncryptionKey(from encryptedKey: Data, header: JWEHeader) throws -> Data { return Data() }
-}
-
+// todo: rename to EncryptionKeyManagementContext
 public struct KeyManagementContext {
     let contentEncryptionKey: Data
     let encryptedKey: Data
     let jweHeader: JWEHeader?
+}
+
+public protocol DecryptionKeyManagementMode {
+    var algorithm: KeyManagementAlgorithm { get }
+
+    func determineContentEncryptionKey(from encryptedKey: Data, with header: JWEHeader) throws -> Data
 }
 
 extension KeyManagementAlgorithm {

--- a/JOSESwift/Sources/PBES2KeyEncryptionMode.swift
+++ b/JOSESwift/Sources/PBES2KeyEncryptionMode.swift
@@ -89,7 +89,7 @@ extension PBES2KeyEncryptionMode: EncryptionKeyManagementMode {
 }
 
 extension PBES2KeyEncryptionMode: DecryptionKeyManagementMode {
-    func determineContentEncryptionKey(from encryptedKey: Data, header: JWEHeader) throws -> Data {
+    func determineContentEncryptionKey(from encryptedKey: Data, with header: JWEHeader) throws -> Data {
         guard let saltInput = header.p2s else {
             throw HeaderParsingError.requiredHeaderParameterMissing(parameter: "p2s")
         }

--- a/JOSESwift/Sources/PBES2KeyEncryptionMode.swift
+++ b/JOSESwift/Sources/PBES2KeyEncryptionMode.swift
@@ -59,8 +59,8 @@ extension PBES2KeyEncryptionMode: EncryptionKeyManagementMode {
     var algorithm: KeyManagementAlgorithm {
         keyManagementAlgorithm
     }
-    
-    func determineContentEncryptionKey(with header: JWEHeader) throws -> KeyManagementContext {
+
+    func determineContentEncryptionKey(with header: JWEHeader) throws -> EncryptionKeyManagementModeContext {
         var updatedHeader = header
 
         let saltInput = try SecureRandom.generate(count: pbes2SaltInputLength)
@@ -80,7 +80,7 @@ extension PBES2KeyEncryptionMode: EncryptionKeyManagementMode {
         let contentKey = try SecureRandom.generate(count: contentEncryptionAlgorithm.keyLength)
         let encryptedKey = try AES.wrap(rawKey: contentKey, keyEncryptionKey: derivedKey, algorithm: keyWrapAlgorithm)
 
-        return KeyManagementContext(
+        return .init(
             contentEncryptionKey: contentKey,
             encryptedKey: encryptedKey,
             jweHeader: updatedHeader

--- a/JOSESwift/Sources/RSAKeyEncryptionMode.swift
+++ b/JOSESwift/Sources/RSAKeyEncryptionMode.swift
@@ -62,11 +62,19 @@ enum RSAKeyEncryption {
 }
 
 extension RSAKeyEncryption.EncryptionMode: EncryptionKeyManagementMode {
-    func determineContentEncryptionKey() throws -> (contentEncryptionKey: Data, encryptedKey: Data) {
+    var algorithm: KeyManagementAlgorithm {
+        keyManagementAlgorithm
+    }
+    
+    func determineContentEncryptionKey(with _: JWEHeader) throws -> KeyManagementContext {
         let contentEncryptionKey = try SecureRandom.generate(count: contentEncryptionAlgorithm.keyLength)
         let encryptedKey = try RSA.encrypt(contentEncryptionKey, with: recipientPublicKey, and: keyManagementAlgorithm)
 
-        return (contentEncryptionKey, encryptedKey)
+        return KeyManagementContext(
+            contentEncryptionKey: contentEncryptionKey,
+            encryptedKey: encryptedKey,
+            jweHeader: nil
+        )
     }
 }
 

--- a/JOSESwift/Sources/RSAKeyEncryptionMode.swift
+++ b/JOSESwift/Sources/RSAKeyEncryptionMode.swift
@@ -79,7 +79,11 @@ extension RSAKeyEncryption.EncryptionMode: EncryptionKeyManagementMode {
 }
 
 extension RSAKeyEncryption.DecryptionMode: DecryptionKeyManagementMode {
-    func determineContentEncryptionKey(from encryptedKey: Data) throws -> Data {
+    var algorithm: KeyManagementAlgorithm {
+        keyManagementAlgorithm
+    }
+
+    func determineContentEncryptionKey(from encryptedKey: Data, with header: JWEHeader) throws -> Data {
         // Generate a random CEK to substitue in case we fail to decrypt the CEK.
         // This is to prevent the MMA (Million Message Attack) against RSA.
         // For detailed information, please refer to RFC-3218 (https://tools.ietf.org/html/rfc3218#section-2.3.2),

--- a/JOSESwift/Sources/RSAKeyEncryptionMode.swift
+++ b/JOSESwift/Sources/RSAKeyEncryptionMode.swift
@@ -65,12 +65,12 @@ extension RSAKeyEncryption.EncryptionMode: EncryptionKeyManagementMode {
     var algorithm: KeyManagementAlgorithm {
         keyManagementAlgorithm
     }
-    
-    func determineContentEncryptionKey(with _: JWEHeader) throws -> KeyManagementContext {
+
+    func determineContentEncryptionKey(with _: JWEHeader) throws -> EncryptionKeyManagementModeContext {
         let contentEncryptionKey = try SecureRandom.generate(count: contentEncryptionAlgorithm.keyLength)
         let encryptedKey = try RSA.encrypt(contentEncryptionKey, with: recipientPublicKey, and: keyManagementAlgorithm)
 
-        return KeyManagementContext(
+        return .init(
             contentEncryptionKey: contentEncryptionKey,
             encryptedKey: encryptedKey,
             jweHeader: nil

--- a/JOSESwift/Sources/Signer.swift
+++ b/JOSESwift/Sources/Signer.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-protocol SignerProtocol {
+public protocol SignerProtocol {
     var algorithm: SignatureAlgorithm { get }
 
     /// Signs input data.
@@ -35,7 +35,7 @@ protocol SignerProtocol {
     func sign(_ signingInput: Data) throws -> Data
 }
 
-public struct Signer<KeyType> {
+public struct Signer {
     let signer: SignerProtocol
 
     /// Constructs a signer used to sign a JWS.
@@ -49,7 +49,7 @@ public struct Signer<KeyType> {
     ///     - For _MAC algorithms_ it is the secret symmetric key (`Data`)
     ///       shared between the sender and the recipient.
     /// - Returns: A fully initialized `Signer` or `nil` if provided key is of the wrong type.
-    public init?(signingAlgorithm: SignatureAlgorithm, key: KeyType) {
+    public init?<KeyType>(signingAlgorithm: SignatureAlgorithm, key: KeyType) {
         switch signingAlgorithm {
         case .HS256, .HS384, .HS512:
             guard type(of: key) is HMACSigner.KeyType.Type else {
@@ -70,6 +70,10 @@ public struct Signer<KeyType> {
             // swiftlint:disable:next force_cast
             self.signer = ECSigner(algorithm: signingAlgorithm, privateKey: key as! ECSigner.KeyType)
         }
+    }
+
+    public init(customSigner signer: SignerProtocol) {
+        self.signer = signer
     }
 
     internal func sign(header: JWSHeader, payload: Payload) throws -> Data {
@@ -99,7 +103,7 @@ extension Array where Element == DataConvertible {
 
 extension Signer {
     @available(*, deprecated, message: "Use `init?(signingAlgorithm: SignatureAlgorithm, key: KeyType)` instead")
-    public init?(signingAlgorithm: SignatureAlgorithm, privateKey: KeyType) {
+    public init?<KeyType>(signingAlgorithm: SignatureAlgorithm, privateKey: KeyType) {
         self.init(signingAlgorithm: signingAlgorithm, key: privateKey)
     }
 }

--- a/JOSESwift/Sources/Signer.swift
+++ b/JOSESwift/Sources/Signer.swift
@@ -72,6 +72,13 @@ public struct Signer {
         }
     }
 
+    /// Constructs a signer used to sign a JWS.
+    ///
+    /// - Parameters:
+    ///   - customSigner: A custom signing implementation.
+    ///
+    ///   It is the implementors responsibility to ensure compliance with the necessary specifications.
+    /// - Returns: A fully initialized `Signer`.
     public init(customSigner signer: SignerProtocol) {
         self.signer = signer
     }

--- a/JOSESwift/Sources/Verifier.swift
+++ b/JOSESwift/Sources/Verifier.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-protocol VerifierProtocol {
+public protocol VerifierProtocol {
     var algorithm: SignatureAlgorithm { get }
 
     /// Verifies a signature against a given signing input with a specific algorithm and the corresponding key.
@@ -71,6 +71,10 @@ public struct Verifier {
             }
             self.verifier = ECVerifier(algorithm: verifyingAlgorithm, publicKey: key as! ECVerifier.KeyType)
         }
+    }
+
+    public init(customVerifier verifier: VerifierProtocol) {
+        self.verifier = verifier
     }
 
     internal func verify(header: JWSHeader, and payload: Payload, against signature: Data) throws -> Bool {

--- a/JOSESwift/Sources/Verifier.swift
+++ b/JOSESwift/Sources/Verifier.swift
@@ -73,6 +73,13 @@ public struct Verifier {
         }
     }
 
+    /// Constructs a verifier used to verify a JWS signature.
+    ///
+    /// - Parameters:
+    ///   - customVerifier: A custom signature verification implementation.
+    ///
+    ///   It is the implementors responsibility to ensure compliance with the necessary specifications.
+    /// - Returns: A fully initialized `Verifier`.
     public init(customVerifier verifier: VerifierProtocol) {
         self.verifier = verifier
     }

--- a/Tests/AESCBCContentDecryptionTests.swift
+++ b/Tests/AESCBCContentDecryptionTests.swift
@@ -36,8 +36,8 @@ class AESCBCContentDecryptionTests: XCTestCase {
         let authenticationTag = "65 2c 3f a3 6b 0a 7c 5b 32 19 fa b3 a3 0b c1 c4".hexadecimalToData()!
         let testPlaintext = "41 20 63 69 70 68 65 72 20 73 79 73 74 65 6d 20 6d 75 73 74 20 6e 6f 74 20 62 65 20 72 65 71 75 69 72 65 64 20 74 6f 20 62 65 20 73 65 63 72 65 74 2c 20 61 6e 64 20 69 74 20 6d 75 73 74 20 62 65 20 61 62 6c 65 20 74 6f 20 66 61 6c 6c 20 69 6e 74 6f 20 74 68 65 20 68 61 6e 64 73 20 6f 66 20 74 68 65 20 65 6e 65 6d 79 20 77 69 74 68 6f 75 74 20 69 6e 63 6f 6e 76 65 6e 69 65 6e 63 65".hexadecimalToData()!
 
-        let decrypter = try! AESCBCEncryption(contentEncryptionAlgorithm: .A128CBCHS256, secretKey: secretKey)
-        let plaintext = try! decrypter.decrypt(ciphertext, initializationVector: iv, additionalAuthenticatedData: additionalAuthenticatedData, authenticationTag: authenticationTag)
+        let decrypter = try! AESCBCEncryption(contentEncryptionAlgorithm: .A128CBCHS256)
+        let plaintext = try! decrypter.decrypt(ciphertext, initializationVector: iv, additionalAuthenticatedData: additionalAuthenticatedData, authenticationTag: authenticationTag, contentEncryptionKey: secretKey)
 
         XCTAssertEqual(plaintext, testPlaintext)
     }
@@ -51,8 +51,8 @@ class AESCBCContentDecryptionTests: XCTestCase {
         let authenticationTag = "84 90 ac 0e 58 94 9b fe 51 87 5d 73 3f 93 ac 20 75 16 80 39 cc c7 33 d7".hexadecimalToData()!
         let testPlaintext = "41 20 63 69 70 68 65 72 20 73 79 73 74 65 6d 20 6d 75 73 74 20 6e 6f 74 20 62 65 20 72 65 71 75 69 72 65 64 20 74 6f 20 62 65 20 73 65 63 72 65 74 2c 20 61 6e 64 20 69 74 20 6d 75 73 74 20 62 65 20 61 62 6c 65 20 74 6f 20 66 61 6c 6c 20 69 6e 74 6f 20 74 68 65 20 68 61 6e 64 73 20 6f 66 20 74 68 65 20 65 6e 65 6d 79 20 77 69 74 68 6f 75 74 20 69 6e 63 6f 6e 76 65 6e 69 65 6e 63 65".hexadecimalToData()!
 
-        let decrypter = try! AESCBCEncryption(contentEncryptionAlgorithm: .A192CBCHS384, secretKey: secretKey)
-        let plaintext = try! decrypter.decrypt(ciphertext, initializationVector: iv, additionalAuthenticatedData: additionalAuthenticatedData, authenticationTag: authenticationTag)
+        let decrypter = try! AESCBCEncryption(contentEncryptionAlgorithm: .A192CBCHS384)
+        let plaintext = try! decrypter.decrypt(ciphertext, initializationVector: iv, additionalAuthenticatedData: additionalAuthenticatedData, authenticationTag: authenticationTag, contentEncryptionKey: secretKey)
 
         XCTAssertEqual(plaintext, testPlaintext)
     }
@@ -70,10 +70,11 @@ class AESCBCContentDecryptionTests: XCTestCase {
             ciphertext: ciphertext,
             initializationVector: iv,
             additionalAuthenticatedData: additionalAuthenticatedData,
-            authenticationTag: authenticationTag
+            authenticationTag: authenticationTag,
+            contentEncryptionKey: secretKey
         )
 
-        let decrypter: ContentDecrypter = try! AESCBCEncryption(contentEncryptionAlgorithm: .A128CBCHS256, secretKey: secretKey)
+        let decrypter: ContentDecrypter = try! AESCBCEncryption(contentEncryptionAlgorithm: .A128CBCHS256)
         let plaintext = try! decrypter.decrypt(decryptionContext: context)
 
         XCTAssertEqual(plaintext, testPlaintext)
@@ -113,8 +114,8 @@ class AESCBCContentDecryptionTests: XCTestCase {
         69 6e 63 6f 6e 76 65 6e 69 65 6e 63 65
         """.hexadecimalToData()!
 
-        let decrypter = try! AESCBCEncryption(contentEncryptionAlgorithm: .A256CBCHS512, secretKey: secretKey)
-        let plaintext = try! decrypter.decrypt(ciphertext, initializationVector: iv, additionalAuthenticatedData: additionalAuthenticatedData, authenticationTag: authenticationTag)
+        let decrypter = try! AESCBCEncryption(contentEncryptionAlgorithm: .A256CBCHS512)
+        let plaintext = try! decrypter.decrypt(ciphertext, initializationVector: iv, additionalAuthenticatedData: additionalAuthenticatedData, authenticationTag: authenticationTag, contentEncryptionKey: secretKey)
 
         XCTAssertEqual(plaintext, testPlaintext)
     }
@@ -157,10 +158,11 @@ class AESCBCContentDecryptionTests: XCTestCase {
             ciphertext: ciphertext,
             initializationVector: iv,
             additionalAuthenticatedData: additionalAuthenticatedData,
-            authenticationTag: authenticationTag
+            authenticationTag: authenticationTag,
+            contentEncryptionKey: secretKey
         )
 
-        let decrypter: ContentDecrypter = try! AESCBCEncryption(contentEncryptionAlgorithm: .A256CBCHS512, secretKey: secretKey)
+        let decrypter: ContentDecrypter = try! AESCBCEncryption(contentEncryptionAlgorithm: .A256CBCHS512)
         let plaintext = try! decrypter.decrypt(decryptionContext: context)
 
         XCTAssertEqual(plaintext, testPlaintext)

--- a/Tests/AESKeyWrapKeyManagementModeTests.swift
+++ b/Tests/AESKeyWrapKeyManagementModeTests.swift
@@ -180,6 +180,8 @@ class AESKeyWrapKeyManagementModeTests: XCTestCase {
     func testDecryptingFailsForWrongAlgorithm() throws {
         let rsaKeyManagementModeAlgorithms: [KeyManagementAlgorithm] = [.RSA1_5, .RSAOAEP, .RSAOAEP256]
         for algorithm in rsaKeyManagementModeAlgorithms {
+            let header = JWEHeader(keyManagementAlgorithm: algorithm, contentEncryptionAlgorithm: .A128CBCHS256)
+
             let keyEncryption = AESKeyWrappingMode(
                 keyManagementAlgorithm: algorithm,
                 contentEncryptionAlgorithm: .A128CBCHS256,
@@ -187,7 +189,7 @@ class AESKeyWrapKeyManagementModeTests: XCTestCase {
             )
 
             XCTAssertThrowsError(
-                try keyEncryption.determineContentEncryptionKey(from: Data()), "Invalid algorithm"
+                try keyEncryption.determineContentEncryptionKey(from: Data(), with: header), "Invalid algorithm"
             ) { error in
                 XCTAssertEqual(error as! AESError, AESError.invalidAlgorithm)
             }
@@ -196,6 +198,8 @@ class AESKeyWrapKeyManagementModeTests: XCTestCase {
 
     // Test data taken from RFC-3394, 4 (https://tools.ietf.org/html/rfc3394#section-4).
     func testDecryptsContentEncryptionKeyAndChecksLengthForContentEncryption() throws {
+        let header = JWEHeader(keyManagementAlgorithm: .A128KW, contentEncryptionAlgorithm: .A128CBCHS256)
+
         let keyEncryption = AESKeyWrappingMode(
             keyManagementAlgorithm: .A128KW,
             contentEncryptionAlgorithm: .A128CBCHS256,
@@ -204,7 +208,8 @@ class AESKeyWrapKeyManagementModeTests: XCTestCase {
 
         XCTAssertThrowsError(
             try keyEncryption.determineContentEncryptionKey(
-                from: "1FA68B0A8112B447AEF34BD8FB5A7B829D3E862371D2CFE5".hexadecimalToData()!
+                from: "1FA68B0A8112B447AEF34BD8FB5A7B829D3E862371D2CFE5".hexadecimalToData()!,
+                with: header
             )
         ) { error in
             XCTAssertEqual(error as! AESError, AESError.keyLengthNotSatisfied)

--- a/Tests/AESKeyWrapKeyManagementModeTests.swift
+++ b/Tests/AESKeyWrapKeyManagementModeTests.swift
@@ -55,41 +55,53 @@ class AESKeyWrapKeyManagementModeTests: XCTestCase {
 
     func testGeneratesRandomContentEncryptionKeyOnEachCall() throws {
         for algorithm in keyManagementModeAlgorithms {
+            let header = JWEHeader(keyManagementAlgorithm: algorithm, contentEncryptionAlgorithm: .A128CBCHS256)
+
             let keyEncryption = AESKeyWrappingMode(
                 keyManagementAlgorithm: algorithm,
                 contentEncryptionAlgorithm: .A128CBCHS256,
                 sharedSymmetricKey: symmetricKeys[algorithm]!
             )
 
-            let (cek1, _) = try keyEncryption.determineContentEncryptionKey()
-            let (cek2, _) = try keyEncryption.determineContentEncryptionKey()
+            let context1 = try keyEncryption.determineContentEncryptionKey(with: header)
+            let context2 = try keyEncryption.determineContentEncryptionKey(with: header)
 
-            XCTAssertNotEqual(cek1, cek2)
+            XCTAssertNotEqual(context1.contentEncryptionKey, context2.contentEncryptionKey)
+            XCTAssertNotEqual(context1.encryptedKey, context2.encryptedKey)
+            XCTAssertNil(context1.jweHeader)
+            XCTAssertNil(context2.jweHeader)
         }
     }
 
     func testFailsForWrongKeySize() throws {
         for algorithm in keyManagementModeAlgorithms {
+            let header = JWEHeader(keyManagementAlgorithm: algorithm, contentEncryptionAlgorithm: .A128CBCHS256)
+
             let keyEncryption = AESKeyWrappingMode(
                 keyManagementAlgorithm: algorithm,
                 contentEncryptionAlgorithm: .A128CBCHS256,
                 sharedSymmetricKey: Data(count: 10)
             )
 
-            XCTAssertThrowsError(try keyEncryption.determineContentEncryptionKey())
+            XCTAssertThrowsError(try keyEncryption.determineContentEncryptionKey(with: header))
         }
     }
 
     func testEncryptingFailsForWrongAlgorithm() throws {
         let rsaKeyManagementModeAlgorithms: [KeyManagementAlgorithm] = [.RSA1_5, .RSAOAEP, .RSAOAEP256]
         for algorithm in rsaKeyManagementModeAlgorithms {
+            let header = JWEHeader(keyManagementAlgorithm: algorithm, contentEncryptionAlgorithm: .A128CBCHS256)
+
             let keyEncryption = AESKeyWrappingMode(
                 keyManagementAlgorithm: algorithm,
                 contentEncryptionAlgorithm: .A128CBCHS256,
                 sharedSymmetricKey: symmetricKeys[.A128KW]!
             )
 
-            XCTAssertThrowsError(try keyEncryption.determineContentEncryptionKey(), "Invalid algorithm") { error in
+            XCTAssertThrowsError(
+                try keyEncryption.determineContentEncryptionKey(with: header),
+                "Invalid algorithm"
+            ) { error in
                 XCTAssertEqual(error as! AESError, AESError.invalidAlgorithm)
             }
         }
@@ -97,47 +109,51 @@ class AESKeyWrapKeyManagementModeTests: XCTestCase {
 
     func testEncryptsContentEncryptionKey() throws {
         for algorithm in keyManagementModeAlgorithms {
+            let header = JWEHeader(keyManagementAlgorithm: algorithm, contentEncryptionAlgorithm: .A128CBCHS256)
+
             let keyEncryption = AESKeyWrappingMode(
                 keyManagementAlgorithm: algorithm,
                 contentEncryptionAlgorithm: .A128CBCHS256,
                 sharedSymmetricKey: symmetricKeys[algorithm]!
             )
 
-            let (cek, encryptedKey) = try keyEncryption.determineContentEncryptionKey()
+            let context = try keyEncryption.determineContentEncryptionKey(with: header)
 
-            XCTAssertNotEqual(cek, encryptedKey)
+            XCTAssertNotEqual(context.contentEncryptionKey, context.encryptedKey)
 
             let decryptedKey = ccAESKeyUnwrap(
-                wrappedKey: encryptedKey,
+                wrappedKey: context.encryptedKey,
                 keyEncryptionKey: symmetricKeys[algorithm]!,
                 iv: Data(bytes: CCrfc3394_iv, count: CCrfc3394_ivLen)
             )
 
-            XCTAssertEqual(decryptedKey.data, cek)
+            XCTAssertEqual(context.contentEncryptionKey, decryptedKey.data)
         }
     }
 
     func testEncryptsContentEncryptionKeyOnlyForProvidedKey() throws {
         for algorithm in keyManagementModeAlgorithms {
+            let header = JWEHeader(keyManagementAlgorithm: algorithm, contentEncryptionAlgorithm: .A128CBCHS256)
+
             let keyEncryption = AESKeyWrappingMode(
                 keyManagementAlgorithm: algorithm,
                 contentEncryptionAlgorithm: .A128CBCHS256,
                 sharedSymmetricKey: symmetricKeys[algorithm]!
             )
 
-            let (cek, encryptedKey) = try keyEncryption.determineContentEncryptionKey()
+            let context = try keyEncryption.determineContentEncryptionKey(with: header)
 
-            XCTAssertNotEqual(cek, encryptedKey)
+            XCTAssertNotEqual(context.contentEncryptionKey, context.encryptedKey)
 
             let wrongKey = Data(repeating: 1, count: symmetricKeys[algorithm]!.count)
 
             let decryptedKey = ccAESKeyUnwrap(
-                wrappedKey: encryptedKey,
+                wrappedKey: context.encryptedKey,
                 keyEncryptionKey: wrongKey,
                 iv: Data(bytes: CCrfc3394_iv, count: CCrfc3394_ivLen)
             )
 
-            XCTAssertNotEqual(decryptedKey.data, cek)
+            XCTAssertNotEqual(context.contentEncryptionKey, decryptedKey.data)
         }
     }
 
@@ -146,15 +162,17 @@ class AESKeyWrapKeyManagementModeTests: XCTestCase {
 
         for alg in keyManagementModeAlgorithms {
             for enc in contentEncryptionAlgorithms {
+                let header = JWEHeader(keyManagementAlgorithm: alg, contentEncryptionAlgorithm: enc)
+
                 let keyEncryption = AESKeyWrappingMode(
                     keyManagementAlgorithm: alg,
                     contentEncryptionAlgorithm: enc,
                     sharedSymmetricKey: symmetricKeys[alg]!
                 )
 
-                let (cek, _) = try keyEncryption.determineContentEncryptionKey()
+                let context = try keyEncryption.determineContentEncryptionKey(with: header)
 
-                XCTAssertEqual(cek.count, enc.keyLength)
+                XCTAssertEqual(context.contentEncryptionKey.count, enc.keyLength)
             }
         }
     }

--- a/Tests/DirectEncryptionKeyManagementModeTests.swift
+++ b/Tests/DirectEncryptionKeyManagementModeTests.swift
@@ -29,22 +29,34 @@ class DirectEncryptionKeyManagementModeTests: XCTestCase {
     let sharedSymmetricKey = "secret".data(using: .utf8)!
 
     func testReturnsSharedSymmeyricKeyAsContentEncryptionKey() throws {
-        let keyEncryption = DirectEncryptionMode(sharedSymmetricKey: sharedSymmetricKey)
+        let header = JWEHeader(keyManagementAlgorithm: .direct, contentEncryptionAlgorithm: .A128CBCHS256)
+        let keyEncryption = DirectEncryptionMode(
+            keyManagementAlgorithm: .direct,
+            sharedSymmetricKey: sharedSymmetricKey
+        )
 
-        let (cek1, _) = try keyEncryption.determineContentEncryptionKey()
-        let (cek2, _) = try keyEncryption.determineContentEncryptionKey()
+        let context1 = try keyEncryption.determineContentEncryptionKey(with: header)
+        let context2 = try keyEncryption.determineContentEncryptionKey(with: header)
 
-        XCTAssertEqual(cek1, sharedSymmetricKey)
-        XCTAssertEqual(cek1, cek2)
+        XCTAssertEqual(context1.contentEncryptionKey, sharedSymmetricKey)
+        XCTAssertEqual(context1.contentEncryptionKey, context2.contentEncryptionKey)
+        XCTAssertEqual(context1.encryptedKey, context2.encryptedKey)
+        XCTAssertNil(context1.jweHeader)
+        XCTAssertNil(context2.jweHeader)
 
     }
 
     func testEncryptedKeyIsEmpty() throws {
-        let keyEncryption = DirectEncryptionMode(sharedSymmetricKey: sharedSymmetricKey)
+        let header = JWEHeader(keyManagementAlgorithm: .direct, contentEncryptionAlgorithm: .A256CBCHS512)
 
-        let (_, encryptedKey) = try keyEncryption.determineContentEncryptionKey()
+        let keyEncryption = DirectEncryptionMode(
+            keyManagementAlgorithm: .direct,
+            sharedSymmetricKey: sharedSymmetricKey
+        )
 
-        XCTAssertEqual(encryptedKey, Data())
+        let context = try keyEncryption.determineContentEncryptionKey(with: header)
+
+        XCTAssertEqual(context.encryptedKey, Data())
     }
 }
 // swiftlint:enable force_unwrapping

--- a/Tests/JWEPBES2Tests.swift
+++ b/Tests/JWEPBES2Tests.swift
@@ -32,14 +32,17 @@ class JWEPBES2Tests: XCTestCase {
         let payload = Payload("Live long and prosper.".data(using: .utf8)!)
         let password = "123456"
 
-        let encrypter = Encrypter(keyManagementAlgorithm: .PBES2_HS256_A128KW, contentEncryptionAlgorithm: .A256CBCHS512, encryptionKey: password)
+        let encrypter = Encrypter(keyManagementAlgorithm: .PBES2_HS256_A128KW, contentEncryptionAlgorithm: .A256CBCHS512, encryptionKey: password, pbes2SaltInputLength: 32)
         let jwe = try JWE(header: header, payload: payload, encrypter: encrypter!)
         let serialization = jwe.compactSerializedString
 
         let deserialization = try JWE(compactSerialization: serialization)
         let decrypter = Decrypter(keyManagementAlgorithm: .PBES2_HS256_A128KW, contentEncryptionAlgorithm: .A256CBCHS512, decryptionKey: password)
         let decrypted = try! deserialization.decrypt(using: decrypter!)
-		XCTAssertEqual(payload.data(), decrypted.data())
+
+        XCTAssertEqual(payload.data(), decrypted.data())
+        XCTAssertEqual(jwe.header.p2c, 1000)
+        XCTAssertEqual(jwe.header.p2s?.count, 32)
     }
 }
 // swiftlint:enable force_unwrapping

--- a/Tests/JWERSATests.swift
+++ b/Tests/JWERSATests.swift
@@ -229,7 +229,7 @@ class JWERSATests: RSACryptoTestCase {
         )!
 
         XCTAssertThrowsError(try jwe.decrypt(using: decrypter), "decrypting with wrong alg in header") { error in
-            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.decryptingFailed(description: "JWE header algorithms do not match encrypter algorithms."))
+            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.keyManagementAlrgorithmMismatch)
         }
     }
 
@@ -249,7 +249,7 @@ class JWERSATests: RSACryptoTestCase {
         )!
 
         XCTAssertThrowsError(try jwe.decrypt(using: decrypter), "decrypting with wrong alg in header with RSA-OAEP-256 algorithm") { error in
-            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.decryptingFailed(description: "JWE header algorithms do not match encrypter algorithms."))
+            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.keyManagementAlrgorithmMismatch)
         }
     }
 
@@ -269,7 +269,7 @@ class JWERSATests: RSACryptoTestCase {
         )!
 
         XCTAssertThrowsError(try jwe.decrypt(using: decrypter), "decrypting with wrong enc in header") { error in
-            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.decryptingFailed(description: "JWE header algorithms do not match encrypter algorithms."))
+            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.contentEncryptionAlgorithmMismatch)
         }
     }
 

--- a/Tests/JWSCustomEncrypterDecrypterTests.swift
+++ b/Tests/JWSCustomEncrypterDecrypterTests.swift
@@ -1,0 +1,119 @@
+// swiftlint:disable force_unwrapping
+//
+//  JWSCustomEncrypterDecrypterTests.swift
+//  Tests
+//
+//  Created by Daniel Egger on 22.02.18.
+//
+//  ---------------------------------------------------------------------------
+//  Copyright 2019 Airside Mobile Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ---------------------------------------------------------------------------
+//
+
+import XCTest
+@testable import JOSESwift
+
+class JWSCustomEncrypterDecrypterTests: XCTestCase {
+    private struct NoOpEncryptionKeyManagementMode: EncryptionKeyManagementMode {
+        var algorithm: KeyManagementAlgorithm = .direct
+
+        func determineContentEncryptionKey(with _: JOSESwift.JWEHeader) throws -> EncryptionKeyManagementModeContext {
+            return .init(contentEncryptionKey: Data(), encryptedKey: Data(), jweHeader: nil)
+        }
+    }
+
+    private struct NoOpContentEncrypter: ContentEncrypter {
+        var algorithm: ContentEncryptionAlgorithm = .A128CBCHS256
+
+        func encrypt(headerData: Data, payload: Payload, contentEncryptionKey: Data) throws -> ContentEncryptionContext {
+            return .init(ciphertext: Data(), authenticationTag: Data(), initializationVector: Data())
+        }
+    }
+
+    private struct NoOpDecryptionKeyManagementMode: DecryptionKeyManagementMode {
+        var algorithm: KeyManagementAlgorithm = .direct
+
+        func determineContentEncryptionKey(from encryptedKey: Data, with header: JOSESwift.JWEHeader) throws -> Data {
+            return Data()
+        }
+    }
+
+    private struct NoOpContentDecrypter: ContentDecrypter {
+        var algorithm: ContentEncryptionAlgorithm = .A128CBCHS256
+
+        func decrypt(decryptionContext: JOSESwift.ContentDecryptionContext) throws -> Data {
+            return Data()
+        }
+    }
+
+    func testCustomEncryption() throws {
+        let header = JWEHeader(keyManagementAlgorithm: .direct, contentEncryptionAlgorithm: .A128CBCHS256)
+        let payload = Payload("Summer, Sun, Cactus".data(using: .utf8)!)
+        let customKeyManagementMode = NoOpEncryptionKeyManagementMode()
+        let customContentEncrypter = NoOpContentEncrypter()
+        let customEncrypter = Encrypter(
+            customKeyManagementMode: customKeyManagementMode,
+            customContentEncrypter: customContentEncrypter
+        )
+
+        let jwe = try JWE(header: header, payload: payload, encrypter: customEncrypter)
+
+        XCTAssertEqual(jwe.ciphertext, Data())
+        XCTAssertEqual(jwe.authenticationTag, Data())
+        XCTAssertEqual(jwe.initializationVector, Data())
+        XCTAssertEqual(jwe.encryptedKey, Data())
+        XCTAssertEqual(jwe.header.keyManagementAlgorithm, .direct)
+        XCTAssertEqual(jwe.header.contentEncryptionAlgorithm, .A128CBCHS256)
+    }
+
+    func testCustomDecryption() throws {
+        let header = JWEHeader(keyManagementAlgorithm: .direct, contentEncryptionAlgorithm: .A128CBCHS256)
+        let payload = Payload("Summer, Sun, Cactus".data(using: .utf8)!)
+
+        let customEncyptionKeyManagementMode = NoOpEncryptionKeyManagementMode()
+        let customContentEncrypter = NoOpContentEncrypter()
+        let customEncrypter = Encrypter(
+            customKeyManagementMode: customEncyptionKeyManagementMode,
+            customContentEncrypter: customContentEncrypter
+        )
+
+        let testDummyKey = "not-so-secret".data(using: .utf8)!
+        let joseDecrypter = Decrypter(
+            keyManagementAlgorithm: .direct,
+            contentEncryptionAlgorithm: .A128CBCHS256,
+            decryptionKey: testDummyKey
+        )!
+
+        let customDecryptionKeyManagementMode = NoOpDecryptionKeyManagementMode()
+        let customContentDecrypter = NoOpContentDecrypter()
+        let customDecrypter = Decrypter(
+            customKeyManagementMode: customDecryptionKeyManagementMode,
+            customContentDecrypter: customContentDecrypter
+        )
+
+        let jwe = try JWE(header: header, payload: payload, encrypter: customEncrypter)
+
+        let customDecryptedPayload = try jwe.decrypt(using: customDecrypter)
+
+        XCTAssertEqual(customDecryptedPayload.data(), Data())
+        XCTAssertEqual(jwe.header.keyManagementAlgorithm, .direct)
+        XCTAssertEqual(jwe.header.contentEncryptionAlgorithm, .A128CBCHS256)
+
+        XCTAssertThrowsError(try jwe.decrypt(using: joseDecrypter)) { (error: Error) in
+            XCTAssertEqual(error as! JOSESwiftError, .decryptingFailed(description: "The operation couldn’t be completed. (JOSESwift.JWEError error 2.)"))
+        }
+    }
+}
+// swiftlint:enable force_unwrapping

--- a/Tests/JWSCustomSignerVerifierTests.swift
+++ b/Tests/JWSCustomSignerVerifierTests.swift
@@ -1,0 +1,70 @@
+// swiftlint:disable force_unwrapping
+//
+//  JWSCustomSignerVerifierTests.swift
+//  Tests
+//
+//  Created by Daniel Egger on 22.02.18.
+//
+//  ---------------------------------------------------------------------------
+//  Copyright 2019 Airside Mobile Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ---------------------------------------------------------------------------
+//
+
+import XCTest
+@testable import JOSESwift
+
+class JWSCustomSignerVerifierTests: XCTestCase {
+    private struct NoOpSigner: SignerProtocol {
+        var algorithm: SignatureAlgorithm = .HS256
+
+        func sign(_ signingInput: Data) throws -> Data {
+            return Data()
+        }
+    }
+
+    private struct NoOpVerifyer: VerifierProtocol {
+        var algorithm: SignatureAlgorithm = .HS256
+
+        func verify(_ signingInput: Data, against signature: Data) throws -> Bool {
+            return false
+        }
+    }
+
+    func testCustomSigner() throws {
+        let header = JWSHeader(algorithm: .HS256)
+        let payload = Payload("Summer, Sun, Cactus".data(using: .utf8)!)
+        let customSigner = Signer(customSigner: NoOpSigner())
+
+        let jws = try JWS(header: header, payload: payload, signer: customSigner)
+
+        XCTAssertEqual(jws.signature, Data())
+    }
+
+    func testCustomVerifier() throws {
+        let testDummySigningKey = "not-so-secret".data(using: .utf8)!
+
+        let header = JWSHeader(algorithm: .HS256)
+        let payload = Payload("Summer, Sun, Cactus".data(using: .utf8)!)
+        let signer = Signer(signingAlgorithm: .HS256, key: testDummySigningKey)!
+        let joseVerifier = Verifier(verifyingAlgorithm: .HS256, key: testDummySigningKey)!
+        let customVerifier = Verifier(customVerifier: NoOpVerifyer())
+
+        let jws = try JWS(header: header, payload: payload, signer: signer)
+
+        XCTAssertTrue(jws.isValid(for: joseVerifier))
+        XCTAssertFalse(jws.isValid(for: customVerifier))
+    }
+}
+// swiftlint:enable force_unwrapping

--- a/Tests/JWSValidationTests.swift
+++ b/Tests/JWSValidationTests.swift
@@ -128,7 +128,7 @@ class JWSValidationTests: RSACryptoTestCase {
         let verifier = Verifier(verifyingAlgorithm: .RS256, publicKey: publicKeyAlice2048!)!
 
         XCTAssertThrowsError(try jws.validate(using: verifier), "verifying with wrong verifier algorithm") { error in
-            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.verifyingFailed(description: "JWS header algorithm does not match verifier algorithm."))
+            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.signingAlgorithmMismatch)
         }
     }
 
@@ -141,7 +141,7 @@ class JWSValidationTests: RSACryptoTestCase {
         let verifier = Verifier(verifyingAlgorithm: .RS512, publicKey: publicKeyAlice2048!)!
 
         XCTAssertThrowsError(try jws.validate(using: verifier), "verifying with wrong header algorithm") { error in
-            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.verifyingFailed(description: "JWS header algorithm does not match verifier algorithm."))
+            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.signingAlgorithmMismatch)
         }
     }
 

--- a/Tests/PBES2KeyEncryptionModeTests.swift
+++ b/Tests/PBES2KeyEncryptionModeTests.swift
@@ -42,16 +42,9 @@ class PBES2KeyEncryptionModeTests: XCTestCase {
 
         XCTAssertEqual(keyManagementMode.pbes2SaltInputLength, 8)
 
-        let keyManagementEncryptionContextData = try! keyManagementMode.determineContentEncryptionKey(for: jweHeader)
+        let context = try! keyManagementMode.determineContentEncryptionKey(with: jweHeader)
 
-        let keyManagementEncryptionContext = try! JSONDecoder().decode(
-            Encrypter.PBES2EncryptionContext.self,
-            from: keyManagementEncryptionContextData
-        )
-
-        let updatedJWEHeader = JWEHeader(keyManagementEncryptionContext.headerData)!
-
-        XCTAssertEqual(updatedJWEHeader.p2s!.count, 8)
+        XCTAssertEqual(context.jweHeader!.p2s!.count, 8)
     }
 
     func testOkCustomSaltInputLengthGetsAccepted() throws {
@@ -69,16 +62,9 @@ class PBES2KeyEncryptionModeTests: XCTestCase {
 
         XCTAssertEqual(keyManagementMode.pbes2SaltInputLength, 16)
 
-        let keyManagementEncryptionContextData = try! keyManagementMode.determineContentEncryptionKey(for: jweHeader)
+        let context = try! keyManagementMode.determineContentEncryptionKey(with: jweHeader)
 
-        let keyManagementEncryptionContext = try! JSONDecoder().decode(
-            Encrypter.PBES2EncryptionContext.self,
-            from: keyManagementEncryptionContextData
-        )
-
-        let updatedJWEHeader = JWEHeader(keyManagementEncryptionContext.headerData)!
-
-        XCTAssertEqual(updatedJWEHeader.p2s!.count, 16)
+        XCTAssertEqual(context.jweHeader!.p2s!.count, 16)
     }
 
     func testWrongCustomSaltInputLengthGetsIgnored() throws {
@@ -96,16 +82,9 @@ class PBES2KeyEncryptionModeTests: XCTestCase {
 
         XCTAssertEqual(keyManagementMode.pbes2SaltInputLength, 8)
 
-        let keyManagementEncryptionContextData = try! keyManagementMode.determineContentEncryptionKey(for: jweHeader)
+        let context = try! keyManagementMode.determineContentEncryptionKey(with: jweHeader)
 
-        let keyManagementEncryptionContext = try! JSONDecoder().decode(
-            Encrypter.PBES2EncryptionContext.self,
-            from: keyManagementEncryptionContextData
-        )
-
-        let updatedJWEHeader = JWEHeader(keyManagementEncryptionContext.headerData)!
-
-        XCTAssertEqual(updatedJWEHeader.p2s!.count, 8)
+        XCTAssertEqual(context.jweHeader!.p2s!.count, 8)
     }
 
     func testHeaderSaltInputGetsIgnored() throws {
@@ -125,16 +104,9 @@ class PBES2KeyEncryptionModeTests: XCTestCase {
 
         XCTAssertEqual(keyManagementMode.pbes2SaltInputLength, 8)
 
-        let keyManagementEncryptionContextData = try! keyManagementMode.determineContentEncryptionKey(for: jweHeader)
+        let context = try! keyManagementMode.determineContentEncryptionKey(with: jweHeader)
 
-        let keyManagementEncryptionContext = try! JSONDecoder().decode(
-            Encrypter.PBES2EncryptionContext.self,
-            from: keyManagementEncryptionContextData
-        )
-
-        let updatedJWEHeader = JWEHeader(keyManagementEncryptionContext.headerData)!
-
-        XCTAssertEqual(updatedJWEHeader.p2s!.count, 8)
+        XCTAssertEqual(context.jweHeader!.p2s!.count, 8)
     }
 
     func testDefaultIterationCount() throws {
@@ -149,42 +121,28 @@ class PBES2KeyEncryptionModeTests: XCTestCase {
             password: testDummyPassword
         )
 
-        let keyManagementEncryptionContextData = try! keyManagementMode.determineContentEncryptionKey(for: jweHeader)
+        let context = try! keyManagementMode.determineContentEncryptionKey(with: jweHeader)
 
-        let keyManagementEncryptionContext = try! JSONDecoder().decode(
-            Encrypter.PBES2EncryptionContext.self,
-            from: keyManagementEncryptionContextData
+        XCTAssertEqual(context.jweHeader!.p2c!, 1_000)
+    }
+
+    func testCustomIterationCountGetsAccepted() throws {
+        var jweHeader = JWEHeader(
+            keyManagementAlgorithm: .PBES2_HS256_A128KW,
+            contentEncryptionAlgorithm: .A128CBCHS256
         )
 
-        let updatedJWEHeader = JWEHeader(keyManagementEncryptionContext.headerData)!
+        jweHeader.p2c = 1_000_000
 
-        XCTAssertEqual(updatedJWEHeader.p2c!, 1_000)
+        let keyManagementMode = PBES2KeyEncryptionMode(
+            keyManagementAlgorithm: jweHeader.keyManagementAlgorithm!,
+            contentEncryptionAlgorithm: jweHeader.contentEncryptionAlgorithm!,
+            password: testDummyPassword
+        )
 
-        func testCustomIterationCountGetsAccepted() throws {
-            var jweHeader = JWEHeader(
-                keyManagementAlgorithm: .PBES2_HS256_A128KW,
-                contentEncryptionAlgorithm: .A128CBCHS256
-            )
+        let context = try! keyManagementMode.determineContentEncryptionKey(with: jweHeader)
 
-            jweHeader.p2c = 1_000_000
-
-            let keyManagementMode = PBES2KeyEncryptionMode(
-                keyManagementAlgorithm: jweHeader.keyManagementAlgorithm!,
-                contentEncryptionAlgorithm: jweHeader.contentEncryptionAlgorithm!,
-                password: testDummyPassword
-            )
-
-            let keyManagementEncryptionContextData = try! keyManagementMode.determineContentEncryptionKey(for: jweHeader)
-
-            let keyManagementEncryptionContext = try! JSONDecoder().decode(
-                Encrypter.PBES2EncryptionContext.self,
-                from: keyManagementEncryptionContextData
-            )
-
-            let updatedJWEHeader = JWEHeader(keyManagementEncryptionContext.headerData)!
-
-            XCTAssertEqual(updatedJWEHeader.p2c!, 1_000_000)
-        }
+        XCTAssertEqual(context.jweHeader!.p2c!, 1_000_000)
     }
 }
 // swiftlint:enable force_unwrapping

--- a/Tests/RSAKeyManagementModeTests.swift
+++ b/Tests/RSAKeyManagementModeTests.swift
@@ -31,63 +31,72 @@ class RSAKeyManagementModeTests: RSACryptoTestCase {
 
     func testGeneratesRandomContentEncryptionKeyOnEachCall() throws {
         for algorithm in keyManagementModeAlgorithms {
+            let header = JWEHeader(keyManagementAlgorithm: algorithm, contentEncryptionAlgorithm: .A256CBCHS512)
+
             let keyEncryption = RSAKeyEncryption.EncryptionMode(
                 keyManagementAlgorithm: algorithm,
                 contentEncryptionAlgorithm: .A256CBCHS512,
                 recipientPublicKey: publicKeyAlice2048!
             )
 
-            let (cek1, _) = try keyEncryption.determineContentEncryptionKey()
-            let (cek2, _) = try keyEncryption.determineContentEncryptionKey()
+            let context1 = try keyEncryption.determineContentEncryptionKey(with: header)
+            let context2 = try keyEncryption.determineContentEncryptionKey(with: header)
 
-            XCTAssertNotEqual(cek1, cek2)
+            XCTAssertNotEqual(context1.contentEncryptionKey, context2.contentEncryptionKey)
+            XCTAssertNotEqual(context1.encryptedKey, context2.encryptedKey)
+            XCTAssertNil(context1.jweHeader)
+            XCTAssertNil(context2.jweHeader)
         }
     }
 
     func testEncryptsContentEncryptionKey() throws {
         for algorithm in keyManagementModeAlgorithms {
+            let header = JWEHeader(keyManagementAlgorithm: algorithm, contentEncryptionAlgorithm: .A256CBCHS512)
+
             let keyEncryption = RSAKeyEncryption.EncryptionMode(
                 keyManagementAlgorithm: algorithm,
                 contentEncryptionAlgorithm: .A256CBCHS512,
                 recipientPublicKey: publicKeyAlice2048!
             )
 
-            let (cek, encryptedKey) = try keyEncryption.determineContentEncryptionKey()
+            let context = try keyEncryption.determineContentEncryptionKey(with: header)
 
-            XCTAssertNotEqual(cek, encryptedKey)
+            XCTAssertNotEqual(context.contentEncryptionKey, context.encryptedKey)
 
             var decryptionError: Unmanaged<CFError>?
             let decryptedKey = SecKeyCreateDecryptedData(
                 privateKeyAlice2048!,
                 algorithm.secKeyAlgorithm!,
-                encryptedKey as CFData,
+                context.encryptedKey as CFData,
                 &decryptionError
             )
 
             XCTAssertNil(decryptionError)
             XCTAssertNotNil(decryptedKey)
 
-            XCTAssertEqual(cek, decryptedKey! as Data)
+            XCTAssertEqual(context.contentEncryptionKey, decryptedKey! as Data)
         }
     }
 
     func testEncryptsContentEncryptionKeyOnlyForProvidedKey() throws {
         for algorithm in keyManagementModeAlgorithms {
+            let header = JWEHeader(keyManagementAlgorithm: algorithm, contentEncryptionAlgorithm: .A256CBCHS512)
+
             let keyEncryption = RSAKeyEncryption.EncryptionMode(
                 keyManagementAlgorithm: algorithm,
                 contentEncryptionAlgorithm: .A256CBCHS512,
                 recipientPublicKey: publicKeyAlice2048!
             )
 
-            let (cek, encryptedKey) = try keyEncryption.determineContentEncryptionKey()
+            let context = try keyEncryption.determineContentEncryptionKey(with: header)
 
-            XCTAssertNotEqual(cek, encryptedKey)
+            XCTAssertNotEqual(context.contentEncryptionKey, context.encryptedKey)
 
             var decryptionError: Unmanaged<CFError>?
             let decryptedKey = SecKeyCreateDecryptedData(
                 privateKeyBob2048!,
                 algorithm.secKeyAlgorithm!,
-                encryptedKey as CFData,
+                context.encryptedKey as CFData,
                 &decryptionError
             )
 
@@ -101,15 +110,17 @@ class RSAKeyManagementModeTests: RSACryptoTestCase {
 
         for alg in keyManagementModeAlgorithms {
             for enc in contentEncryptionAlgorithms {
+                let header = JWEHeader(keyManagementAlgorithm: alg, contentEncryptionAlgorithm: enc)
+
                 let keyEncryption = RSAKeyEncryption.EncryptionMode(
                     keyManagementAlgorithm: alg,
                     contentEncryptionAlgorithm: enc,
                     recipientPublicKey: publicKeyAlice2048!
                 )
 
-                let (cek, _) = try keyEncryption.determineContentEncryptionKey()
+                let context = try keyEncryption.determineContentEncryptionKey(with: header)
 
-                XCTAssertEqual(cek.count, enc.keyLength)
+                XCTAssertEqual(context.contentEncryptionKey.count, enc.keyLength)
             }
         }
     }

--- a/Tests/RSAKeyManagementModeTests.swift
+++ b/Tests/RSAKeyManagementModeTests.swift
@@ -128,6 +128,11 @@ class RSAKeyManagementModeTests: RSACryptoTestCase {
     func testDecryptsContentEncryptionKey() throws {
         let contentEncryptionAlgorithm = ContentEncryptionAlgorithm.A128CBCHS256
         for algorithm in keyManagementModeAlgorithms {
+            let header = JWEHeader(
+                keyManagementAlgorithm: algorithm,
+                contentEncryptionAlgorithm: contentEncryptionAlgorithm
+            )
+
             let keyDecryption = RSAKeyEncryption.DecryptionMode(
                 keyManagementAlgorithm: algorithm,
                 contentEncryptionAlgorithm: contentEncryptionAlgorithm,
@@ -141,7 +146,7 @@ class RSAKeyManagementModeTests: RSACryptoTestCase {
                 and: algorithm
             )
 
-            let decryptedKey = try keyDecryption.determineContentEncryptionKey(from: encryptedKey)
+            let decryptedKey = try keyDecryption.determineContentEncryptionKey(from: encryptedKey, with: header)
 
             XCTAssertEqual(contentEncryptionKey, decryptedKey)
         }
@@ -152,6 +157,11 @@ class RSAKeyManagementModeTests: RSACryptoTestCase {
     func testDoesNotThrowForDecryptionError() throws {
         let contentEncryptionAlgorithm = ContentEncryptionAlgorithm.A128CBCHS256
         for algorithm in keyManagementModeAlgorithms {
+            let header = JWEHeader(
+                keyManagementAlgorithm: algorithm,
+                contentEncryptionAlgorithm: contentEncryptionAlgorithm
+            )
+
             let keyDecryption = RSAKeyEncryption.DecryptionMode(
                 keyManagementAlgorithm: algorithm,
                 contentEncryptionAlgorithm: contentEncryptionAlgorithm,
@@ -165,7 +175,7 @@ class RSAKeyManagementModeTests: RSACryptoTestCase {
                 and: algorithm
             )
 
-            XCTAssertNoThrow(try keyDecryption.determineContentEncryptionKey(from: encryptedKey))
+            XCTAssertNoThrow(try keyDecryption.determineContentEncryptionKey(from: encryptedKey, with: header))
         }
     }
 
@@ -174,6 +184,11 @@ class RSAKeyManagementModeTests: RSACryptoTestCase {
     func testGeneratesRandomContentEncryptionKeyForMalformedEncryptedKey() throws {
         let contentEncryptionAlgorithm = ContentEncryptionAlgorithm.A128CBCHS256
         for algorithm in keyManagementModeAlgorithms {
+            let header = JWEHeader(
+                keyManagementAlgorithm: algorithm,
+                contentEncryptionAlgorithm: contentEncryptionAlgorithm
+            )
+
             let keyDecryption = RSAKeyEncryption.DecryptionMode(
                 keyManagementAlgorithm: algorithm,
                 contentEncryptionAlgorithm: contentEncryptionAlgorithm,
@@ -182,8 +197,13 @@ class RSAKeyManagementModeTests: RSACryptoTestCase {
 
             let encryptedKey = Data(count: algorithm.maxMessageLength(for: publicKeyAlice2048!)! - 10)
 
-            let randomContentEncryptionKey1 = try keyDecryption.determineContentEncryptionKey(from: encryptedKey)
-            let randomContentEncryptionKey2 = try keyDecryption.determineContentEncryptionKey(from: encryptedKey)
+            let randomContentEncryptionKey1 = try keyDecryption.determineContentEncryptionKey(
+                from: encryptedKey, with: header
+            )
+            let randomContentEncryptionKey2 = try keyDecryption.determineContentEncryptionKey(
+                from: encryptedKey,
+                with: header
+            )
 
             XCTAssertNotEqual(randomContentEncryptionKey1, randomContentEncryptionKey2)
         }


### PR DESCRIPTION
This achieves a few things:

- Refactors away some of the inconsistencies of previous PRs
- Finishes the modularization of the signing/verifying/encrypting/decrypting parts
- Opens up an API for supplying custom signers/verifieers/encrypters/decrypters in addition to the default ones implemented by us

---

## TL;DR of the Customization API

In addition of doing this:

``` swift
let testDummySigningKey = "not-so-secret".data(using: .utf8)!

let header = JWSHeader(algorithm: .HS256)
let payload = Payload("Summer, Sun, Cactus".data(using: .utf8)!)
let signer = Signer(signingAlgorithm: .HS256, key: testDummySigningKey)!

let jws = try JWS(header: header, payload: payload, signer: signer)
```

which will use our default crypto implementations, you can now also do this:

``` swift
struct NoOpSigner: SignerProtocol {
    var algorithm: SignatureAlgorithm = .HS256

    func sign(_ signingInput: Data) throws -> Data {
        return Data()
    }
}

let header = JWSHeader(algorithm: .HS256)
let payload = Payload("Summer, Sun, Cactus".data(using: .utf8)!)
let customSigner = Signer(customSigner: NoOpSigner())

let jws = try JWS(header: header, payload: payload, signer: customSigner)
```

Which will plug in the singer you provide for the signing operations. The protocols you need to conform to are abstracted from the JOSE world and allow you to implement custom signing/encrypting and verifying/decrypting operations that take some generic data as an input and produce some generic result and related artifacts (such as initialization vectors, authentication tags etc.) as an output.

_These protocols are:_

**For custom JWS signing:**

``` swift
public protocol SignerProtocol {
    var algorithm: SignatureAlgorithm { get }

    func sign(_ signingInput: Data) throws -> Data
}
```

**For custom JWS verifying:**

``` swift
public protocol VerifierProtocol {
    var algorithm: SignatureAlgorithm { get }

    func verify(_ signingInput: Data, against signature: Data) throws -> Bool
}
```

**For encrypting and decrypting JWE content encryption keys:**

``` swift
public protocol EncryptionKeyManagementMode {
    var algorithm: KeyManagementAlgorithm { get }

    func determineContentEncryptionKey(with header: JWEHeader) throws -> EncryptionKeyManagementModeContext
}

public protocol DecryptionKeyManagementMode {
    var algorithm: KeyManagementAlgorithm { get }

    func determineContentEncryptionKey(from encryptedKey: Data, with header: JWEHeader) throws -> Data
}
```

**For encrypting and decrypting JWE payload:**

``` swift
public protocol ContentEncrypter {
    var algorithm: ContentEncryptionAlgorithm { get }

    func encrypt(headerData: Data, payload: Payload, contentEncryptionKey: Data) throws -> ContentEncryptionContext
}

public protocol ContentDecrypter {
    var algorithm: ContentEncryptionAlgorithm { get }

    func decrypt(decryptionContext: ContentDecryptionContext) throws -> Data
}
```