### PR TITLE
Update signer and verifier init param name and fix typos

### DIFF
--- a/JOSESwift/Sources/Common/JOSESwiftError.swift
+++ b/JOSESwift/Sources/Common/JOSESwiftError.swift
@@ -54,20 +54,20 @@ public enum JOSESwiftError: Error {
     case invalidCurvePointOctetLength
     case localAuthenticationFailed(errorCode: Int)
 
-    // Compression erros
+    // Compression errors
     case compressionFailed
     case decompressionFailed
     case compressionAlgorithmNotSupported
     case rawDataMustBeGreaterThanZero
     case compressedDataMustBeGreaterThanZero
 
-    // Thumprint computation
+    // Thumbprint computation
     case thumbprintSerialization
 
     // Header errors
     case invalidHeaderParameterValue
 
-    case keyManagementAlrgorithmMismatch
+    case keyManagementAlgorithmMismatch
     case contentEncryptionAlgorithmMismatch
     case signingAlgorithmMismatch
 }

--- a/JOSESwift/Sources/CryptoPrimitives/RSA/RSA.swift
+++ b/JOSESwift/Sources/CryptoPrimitives/RSA/RSA.swift
@@ -29,7 +29,7 @@ internal enum RSAError: Error {
     case signingFailed(description: String)
     case verifyingFailed(description: String)
     case plainTextLengthNotSatisfied
-    case cipherTextLenghtNotSatisfied
+    case cipherTextLengthNotSatisfied
     case encryptingFailed(description: String)
     case decryptingFailed(description: String)
 }
@@ -137,7 +137,7 @@ fileprivate extension KeyManagementAlgorithm {
     /// This length checking is just for usability reasons.
     /// Proper length checking is done in the implementation of iOS'
     /// `SecKeyCreateEncryptedData` and `SecKeyCreateDecryptedData`.
-    func isCipherTextLenghtSatisfied(_ cipherText: Data, for privateKey: SecKey) -> Bool? {
+    func isCipherTextLengthSatisfied(_ cipherText: Data, for privateKey: SecKey) -> Bool? {
         switch self {
         case .RSA1_5:
             // For detailed information about the allowed cipher length for RSAES-PKCS1-v1_5,
@@ -278,9 +278,9 @@ internal struct RSA {
 
         // Check if the cipher text length does not exceed the maximum.
         // e.g. for RSA1_5 the cipher text has the same length as the private key's modulus.
-        guard algorithm.isCipherTextLenghtSatisfied(ciphertext, for: privateKey) == true
+        guard algorithm.isCipherTextLengthSatisfied(ciphertext, for: privateKey) == true
         else {
-            throw RSAError.cipherTextLenghtNotSatisfied
+            throw RSAError.cipherTextLengthNotSatisfied
         }
 
         // Decrypt the cipher text with a given `SecKeyAlgorithm` and a private key.

--- a/JOSESwift/Sources/CryptoPrimitives/SHA/Thumbprint.swift
+++ b/JOSESwift/Sources/CryptoPrimitives/SHA/Thumbprint.swift
@@ -29,7 +29,7 @@ enum ThumbprintError: Error {
 }
 
 fileprivate extension JWKThumbprintAlgorithm {
-    var outputLenght: Int {
+    var outputLength: Int {
         switch self {
         case .SHA256:
             return Int(CC_SHA256_DIGEST_LENGTH)
@@ -56,13 +56,13 @@ internal struct Thumbprint {
             throw ThumbprintError.inputMustBeGreaterThanZero
         }
 
-        let hashBytes = UnsafeMutablePointer<UInt8>.allocate(capacity: algorithm.outputLenght)
+        let hashBytes = UnsafeMutablePointer<UInt8>.allocate(capacity: algorithm.outputLength)
         defer { hashBytes.deallocate() }
 
         input.withUnsafeBytes { buffer in
             algorithm.calculate(input: buffer, output: hashBytes)
         }
 
-        return Data(bytes: hashBytes, count: algorithm.outputLenght).base64URLEncodedString()
+        return Data(bytes: hashBytes, count: algorithm.outputLength).base64URLEncodedString()
     }
 }

--- a/JOSESwift/Sources/JWE/Encrypter.swift
+++ b/JOSESwift/Sources/JWE/Encrypter.swift
@@ -25,7 +25,7 @@ import Foundation
 
 public struct Encrypter {
     private let keyManagementMode: EncryptionKeyManagementMode
-    private let contentEncryper: ContentEncrypter
+    private let contentEncrypter: ContentEncrypter
 
     /// Constructs an encrypter that can be used to encrypt a JWE.
     ///
@@ -58,7 +58,7 @@ public struct Encrypter {
 
         let encrypter = try? contentEncryptionAlgorithm.makeContentEncrypter()
         guard let contentEncrypter = encrypter else { return nil }
-        self.contentEncryper = contentEncrypter
+        self.contentEncrypter = contentEncrypter
     }
 
     /// Constructs an encrypter used to encrypt a JWE.
@@ -74,7 +74,7 @@ public struct Encrypter {
         customContentEncrypter contentEncrypter: ContentEncrypter
     ) {
         self.keyManagementMode = keyManagementMode
-        self.contentEncryper = contentEncrypter
+        self.contentEncrypter = contentEncrypter
     }
 
     internal func encrypt(header: JWEHeader, payload: Payload) throws -> EncryptionContext {
@@ -82,7 +82,7 @@ public struct Encrypter {
             throw JWEError.keyManagementAlgorithmMismatch
         }
 
-        guard let headerEnc = header.contentEncryptionAlgorithm, headerEnc == contentEncryper.algorithm else {
+        guard let headerEnc = header.contentEncryptionAlgorithm, headerEnc == contentEncrypter.algorithm else {
             throw JWEError.contentEncryptionAlgorithmMismatch
         }
 
@@ -94,7 +94,7 @@ public struct Encrypter {
             header
         }
 
-        let contentEncryptionContext = try contentEncryper.encrypt(
+        let contentEncryptionContext = try contentEncrypter.encrypt(
             headerData: updatedHeader.data(),
             payload: payload,
             contentEncryptionKey: keyManagementContext.contentEncryptionKey

--- a/JOSESwift/Sources/JWE/JWE.swift
+++ b/JOSESwift/Sources/JWE/JWE.swift
@@ -48,7 +48,7 @@ public struct JWE {
     /// The ciphertext resulting from authenticated encryption of the plaintext.
     public let ciphertext: Data
 
-    /// The output of an authenticated encryption with associated data that ensures the integrity of the ciphertext and the additional associeated data.
+    /// The output of an authenticated encryption with associated data that ensures the integrity of the ciphertext and the additional associated data.
     public let authenticationTag: Data
 
     /// The compact serialization of this JWE object as string.
@@ -154,7 +154,7 @@ public struct JWE {
             let decryptedData = try decrypter.decrypt(context)
             return Payload(try compressor.decompress(data: decryptedData))
         } catch JWEError.keyManagementAlgorithmMismatch {
-            throw JOSESwiftError.keyManagementAlrgorithmMismatch
+            throw JOSESwiftError.keyManagementAlgorithmMismatch
         } catch JWEError.contentEncryptionAlgorithmMismatch {
             throw JOSESwiftError.contentEncryptionAlgorithmMismatch
         } catch JOSESwiftError.decompressionFailed {

--- a/JOSESwift/Sources/JWE/JWEHeader.swift
+++ b/JOSESwift/Sources/JWE/JWEHeader.swift
@@ -224,7 +224,7 @@ extension JWEHeader: CommonHeaderParameterSpace {
         }
     }
 
-    /// The X.509 URL that referes to a resource for the X.509 public key certificate
+    /// The X.509 URL that refers to a resource for the X.509 public key certificate
     /// or certificate chain corresponding to the key used to encrypt the JWE.
     public var x5u: URL? {
         get {
@@ -339,7 +339,7 @@ extension JWEHeader: CommonHeaderParameterSpace {
         }
     }
 
-    /// Header Parameters used for PBES2 Key Deriviation - PBES2 Salt Input
+    /// Header Parameters used for PBES2 Key Derivation - PBES2 Salt Input
     public var p2s: Data? {
         get {
             guard let parameter = parameters["p2s"] as? String else {
@@ -352,7 +352,7 @@ extension JWEHeader: CommonHeaderParameterSpace {
         }
     }
 
-    /// Header Parameters used for PBES2 Key Deriviation - PBES2 Count
+    /// Header Parameters used for PBES2 Key Derivation - PBES2 Count
     public var p2c: Int? {
         get {
             return parameters["p2c"] as? Int

--- a/JOSESwift/Sources/JWE/KeyManagement/DefaultCrypto/EC/ECKeyEncryption.swift
+++ b/JOSESwift/Sources/JWE/KeyManagement/DefaultCrypto/EC/ECKeyEncryption.swift
@@ -4,6 +4,22 @@
 //
 //  Created by Mikael Rucinsky on 07.12.20.
 //
+//  ---------------------------------------------------------------------------
+//  Copyright 2024 Airside Mobile Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ---------------------------------------------------------------------------
+//
 
 import Foundation
 

--- a/JOSESwift/Sources/JWE/KeyManagement/DefaultCrypto/RSA/RSAKeyEncryptionMode.swift
+++ b/JOSESwift/Sources/JWE/KeyManagement/DefaultCrypto/RSA/RSAKeyEncryptionMode.swift
@@ -84,7 +84,7 @@ extension RSAKeyEncryption.DecryptionMode: DecryptionKeyManagementMode {
     }
 
     func determineContentEncryptionKey(from encryptedKey: Data, with header: JWEHeader) throws -> Data {
-        // Generate a random CEK to substitue in case we fail to decrypt the CEK.
+        // Generate a random CEK to substitute in case we fail to decrypt the CEK.
         // This is to prevent the MMA (Million Message Attack) against RSA.
         // For detailed information, please refer to RFC-3218 (https://tools.ietf.org/html/rfc3218#section-2.3.2),
         // RFC-5246 (https://tools.ietf.org/html/rfc5246#appendix-F.1.1.2),

--- a/JOSESwift/Sources/JWE/KeyManagement/KeyManagementMode.swift
+++ b/JOSESwift/Sources/JWE/KeyManagement/KeyManagementMode.swift
@@ -1,5 +1,5 @@
 //
-//  KeyManaggementMode.swift
+//  KeyManagementMode.swift
 //  JOSESwift
 //
 //  Created by Daniel Egger on 12.02.20.
@@ -158,7 +158,7 @@ private func cast<GivenType, ExpectedType>(
     to _: ExpectedType.Type
 ) -> ExpectedType? {
     // A conditional downcast to the CoreFoundation type SecKey will always succeed.
-    // Therfore we perform runtime type checking to guarantee that the given encryption key's type
+    // Therefore we perform runtime type checking to guarantee that the given encryption key's type
     // matches the type that the respective key management mode expects.
     return (type(of: something) is ExpectedType.Type) ? (something as! ExpectedType) : nil
 }

--- a/JOSESwift/Sources/JWK/EC/ECKeyPair.swift
+++ b/JOSESwift/Sources/JWK/EC/ECKeyPair.swift
@@ -4,10 +4,24 @@
 //
 //  Created by Mikael Rucinsky on 07.12.20.
 //
+//  ---------------------------------------------------------------------------
+//  Copyright 2024 Airside Mobile Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ---------------------------------------------------------------------------
+//
 
 import Foundation
-
-// MARK: Key Pair
 
 public extension ECKeyPair {
 
@@ -20,8 +34,8 @@ public extension ECKeyPair {
                                          kSecAttrKeyType as String: kSecAttrKeyTypeEC,
                                          kSecPrivateKeyAttrs as String: [kSecAttrIsPermanent as String: false]]
         var error: Unmanaged<CFError>?
-        if let eckey: SecKey = SecKeyCreateRandomKey(attributes as CFDictionary, &error) {
-            return try ECPrivateKey(privateKey: eckey, additionalParameters: ["kid": UUID().uuidString])
+        if let ecKey: SecKey = SecKeyCreateRandomKey(attributes as CFDictionary, &error) {
+            return try ECPrivateKey(privateKey: ecKey, additionalParameters: ["kid": UUID().uuidString])
         }
         throw ECKeyPairError.generateECKeyPairFail
     }

--- a/JOSESwift/Sources/JWK/RSA/RSAKeys.swift
+++ b/JOSESwift/Sources/JWK/RSA/RSAKeys.swift
@@ -88,7 +88,7 @@ public protocol ExpressibleAsRSAPrivateKeyComponents {
 
 // MARK: Public Key
 
-/// A JWK holding an RSA pubkic key.
+/// A JWK holding an RSA public key.
 public struct RSAPublicKey: JWK {
     /// The JWK key type.
     public let keyType: JWKKeyType

--- a/JOSESwift/Sources/JWK/Symmetric/SymmetricKeys.swift
+++ b/JOSESwift/Sources/JWK/Symmetric/SymmetricKeys.swift
@@ -92,7 +92,7 @@ public struct SymmetricKey: JWK {
     /// Creates a `SymmetricKey` JWK with the specified symmetric key and optional additional JWK parameters.
     ///
     /// - Parameters:
-    ///   - key: The symmetirc key that the resulting JWK should represent.
+    ///   - key: The symmetric key that the resulting JWK should represent.
     ///   - parameters: Any additional parameters to be contained in the JWK.
     /// - Throws: A `JOSESwiftError` indicating any errors.
     public init(key: ExpressibleAsSymmetricKeyComponents, additionalParameters parameters: [String: String] = [:]) throws {

--- a/JOSESwift/Sources/JWS/JWS.swift
+++ b/JOSESwift/Sources/JWS/JWS.swift
@@ -120,7 +120,7 @@ public struct JWS {
     ///
     /// - Parameter verifier: The verifier containing the public key whose corresponding private key signed the JWS.
     /// - Returns: The JWS on which this function was called if the signature is valid.
-    /// - Throws: A `JOSESwiftError` if the signature is invalid or if errors occured during signature validation.
+    /// - Throws: A `JOSESwiftError` if the signature is invalid or if errors occurred during signature validation.
     public func validate(using verifier: Verifier) throws -> JWS {
         do {
             guard try verifier.verify(header: header, and: payload, against: signature) else {
@@ -139,7 +139,7 @@ public struct JWS {
     ///
     /// - Parameter verifier: The verifier containing the public key whose corresponding private key signed the JWS.
     /// - Returns: `true` if the JWS's signature is valid for the given verifier and the JWS's header and payload.
-    ///            `false` if the signature is not valid or if the singature could not be verified.
+    ///            `false` if the signature is not valid or if the signature could not be verified.
     public func isValid(for verifier: Verifier) -> Bool {
         guard verifier.verifier.algorithm == header.algorithm else {
             return false

--- a/JOSESwift/Sources/JWS/JWSHeader.swift
+++ b/JOSESwift/Sources/JWS/JWSHeader.swift
@@ -161,7 +161,7 @@ extension JWSHeader: CommonHeaderParameterSpace {
         }
     }
 
-    /// The X.509 URL that referes to a resource for the X.509 public key certificate
+    /// The X.509 URL that refers to a resource for the X.509 public key certificate
     /// or certificate chain corresponding to the key used to sign the JWS.
     public var x5u: URL? {
         get {

--- a/JOSESwift/Sources/JWS/Signer.swift
+++ b/JOSESwift/Sources/JWS/Signer.swift
@@ -41,7 +41,7 @@ public struct Signer {
     /// Constructs a signer used to sign a JWS.
     ///
     /// - Parameters:
-    ///   - signingAlgorithm: The desired `SignatureAlgorithm`.
+    ///   - signatureAlgorithm: The desired `SignatureAlgorithm`.
     ///   - key: The key used to compute the JWS's signature or message authentication code (MAC).
     ///     Currently supported key types are: `SecKey` and `Data`.
     ///     - For _digital signature algorithms_ it is the sender's private key (`SecKey`)
@@ -49,26 +49,26 @@ public struct Signer {
     ///     - For _MAC algorithms_ it is the secret symmetric key (`Data`)
     ///       shared between the sender and the recipient.
     /// - Returns: A fully initialized `Signer` or `nil` if provided key is of the wrong type.
-    public init?<KeyType>(signingAlgorithm: SignatureAlgorithm, key: KeyType) {
-        switch signingAlgorithm {
+    public init?<KeyType>(signatureAlgorithm: SignatureAlgorithm, key: KeyType) {
+        switch signatureAlgorithm {
         case .HS256, .HS384, .HS512:
             guard type(of: key) is HMACSigner.KeyType.Type else {
                 return nil
             }
             // swiftlint:disable:next force_cast
-            self.signer = HMACSigner(algorithm: signingAlgorithm, key: key as! HMACSigner.KeyType)
+            self.signer = HMACSigner(algorithm: signatureAlgorithm, key: key as! HMACSigner.KeyType)
         case .RS256, .RS384, .RS512, .PS256, .PS384, .PS512:
             guard type(of: key) is RSASigner.KeyType.Type else {
                 return nil
             }
             // swiftlint:disable:next force_cast
-            self.signer = RSASigner(algorithm: signingAlgorithm, privateKey: key as! RSASigner.KeyType)
+            self.signer = RSASigner(algorithm: signatureAlgorithm, privateKey: key as! RSASigner.KeyType)
         case .ES256, .ES384, .ES512:
             guard type(of: key) is ECSigner.KeyType.Type else {
                 return nil
             }
             // swiftlint:disable:next force_cast
-            self.signer = ECSigner(algorithm: signingAlgorithm, privateKey: key as! ECSigner.KeyType)
+            self.signer = ECSigner(algorithm: signatureAlgorithm, privateKey: key as! ECSigner.KeyType)
         }
     }
 

--- a/JOSESwift/Sources/JWS/Verifier.swift
+++ b/JOSESwift/Sources/JWS/Verifier.swift
@@ -40,7 +40,7 @@ public protocol VerifierProtocol {
 public struct Verifier {
     let verifier: VerifierProtocol
 
-    /// Constructs a verifyer used to verify a JWS.
+    /// Constructs a verifier used to verify a JWS.
     ///
     /// - Parameters:
     ///   - signatureAlgorithm: The desired `SignatureAlgorithm`.

--- a/JOSESwift/Sources/JWS/Verifier.swift
+++ b/JOSESwift/Sources/JWS/Verifier.swift
@@ -43,7 +43,7 @@ public struct Verifier {
     /// Constructs a verifyer used to verify a JWS.
     ///
     /// - Parameters:
-    ///   - verifyingAlgorithm: The desired `SignatureAlgorithm`.
+    ///   - signatureAlgorithm: The desired `SignatureAlgorithm`.
     ///   - key: The key used to verify the JWS's signature or message authentication code (MAC).
     ///     Currently supported key types are: `SecKey` and `Data`.
     ///     - For _digital signature algorithms_ it is the sender's public key (`SecKey`)
@@ -51,25 +51,25 @@ public struct Verifier {
     ///     - For _MAC algorithms_ it is the secret symmetric key (`Data`)
     ///       shared between the sender and the recipient.
     /// - Returns: A fully initialized `Verifier` or `nil` if provided key is of the wrong type.
-    public init?<KeyType>(verifyingAlgorithm: SignatureAlgorithm, key: KeyType) {
-        switch verifyingAlgorithm {
+    public init?<KeyType>(signatureAlgorithm: SignatureAlgorithm, key: KeyType) {
+        switch signatureAlgorithm {
         case .HS256, .HS384, .HS512:
             guard type(of: key) is HMACVerifier.KeyType.Type else {
                 return nil
             }
             // swiftlint:disable:next force_cast
-            self.verifier = HMACVerifier(algorithm: verifyingAlgorithm, key: key as! HMACVerifier.KeyType)
+            self.verifier = HMACVerifier(algorithm: signatureAlgorithm, key: key as! HMACVerifier.KeyType)
         case .RS256, .RS384, .RS512, .PS256, .PS384, .PS512:
             guard type(of: key) is RSAVerifier.KeyType.Type else {
                 return nil
             }
             // swiftlint:disable:next force_cast
-            self.verifier = RSAVerifier(algorithm: verifyingAlgorithm, publicKey: key as! RSAVerifier.KeyType)
+            self.verifier = RSAVerifier(algorithm: signatureAlgorithm, publicKey: key as! RSAVerifier.KeyType)
         case .ES256, .ES384, .ES512:
             guard type(of: key) is ECVerifier.KeyType.Type else {
                 return nil
             }
-            self.verifier = ECVerifier(algorithm: verifyingAlgorithm, publicKey: key as! ECVerifier.KeyType)
+            self.verifier = ECVerifier(algorithm: signatureAlgorithm, publicKey: key as! ECVerifier.KeyType)
         }
     }
 

--- a/Tests/ECDHTests.swift
+++ b/Tests/ECDHTests.swift
@@ -4,6 +4,22 @@
 //
 //  Created by Mikael Rucinsky on 07.12.20.
 //
+//  ---------------------------------------------------------------------------
+//  Copyright 2024 Airside Mobile Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ---------------------------------------------------------------------------
+//
 
 import XCTest
 @testable import JOSESwift

--- a/Tests/JWEECTests.swift
+++ b/Tests/JWEECTests.swift
@@ -4,6 +4,22 @@
 //
 //  Created by Mikael Rucinsky on 07.12.20.
 //
+//  ---------------------------------------------------------------------------
+//  Copyright 2024 Airside Mobile Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  ---------------------------------------------------------------------------
+//
 
 import XCTest
 @testable import JOSESwift

--- a/Tests/JWERSATests.swift
+++ b/Tests/JWERSATests.swift
@@ -215,7 +215,7 @@ class JWERSATests: RSACryptoTestCase {
         )!
 
         XCTAssertThrowsError(try jwe.decrypt(using: decrypter), "decrypting with wrong alg in header") { error in
-            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.keyManagementAlrgorithmMismatch)
+            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.keyManagementAlgorithmMismatch)
         }
     }
 
@@ -235,7 +235,7 @@ class JWERSATests: RSACryptoTestCase {
         )!
 
         XCTAssertThrowsError(try jwe.decrypt(using: decrypter), "decrypting with wrong alg in header with RSA-OAEP-256 algorithm") { error in
-            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.keyManagementAlrgorithmMismatch)
+            XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.keyManagementAlgorithmMismatch)
         }
     }
 

--- a/Tests/JWSCustomSignerVerifierTests.swift
+++ b/Tests/JWSCustomSignerVerifierTests.swift
@@ -57,8 +57,8 @@ class JWSCustomSignerVerifierTests: XCTestCase {
 
         let header = JWSHeader(algorithm: .HS256)
         let payload = Payload("Summer, Sun, Cactus".data(using: .utf8)!)
-        let signer = Signer(signingAlgorithm: .HS256, key: testDummySigningKey)!
-        let joseVerifier = Verifier(verifyingAlgorithm: .HS256, key: testDummySigningKey)!
+        let signer = Signer(signatureAlgorithm: .HS256, key: testDummySigningKey)!
+        let joseVerifier = Verifier(signatureAlgorithm: .HS256, key: testDummySigningKey)!
         let customVerifier = Verifier(customVerifier: NoOpVerifyer())
 
         let jws = try JWS(header: header, payload: payload, signer: signer)

--- a/Tests/JWSECTests.swift
+++ b/Tests/JWSECTests.swift
@@ -45,8 +45,8 @@ class JWSECTests: ECCryptoTestCase {
         let algorithm = SignatureAlgorithm(rawValue: testData.signatureAlgorithm)!
         let header = JWSHeader(algorithm: algorithm)
         let payload = Payload(plainTextPayload.data(using: .utf8)!)
-        let signer = Signer(signingAlgorithm: algorithm, key: testData.privateKey)!
-        let verifier = Verifier(verifyingAlgorithm: algorithm, key: testData.publicKey)!
+        let signer = Signer(signatureAlgorithm: algorithm, key: testData.privateKey)!
+        let verifier = Verifier(signatureAlgorithm: algorithm, key: testData.publicKey)!
         let jws = try! JWS(header: header, payload: payload, signer: signer)
         let compact = jws.compactSerializedString
         let splitCompact = compact.split(separator: ".")

--- a/Tests/JWSHMACTests.swift
+++ b/Tests/JWSHMACTests.swift
@@ -31,7 +31,7 @@ class JWSHMACTests: HMACCryptoTestCase {
         XCTAssertEqual("{\"alg\":\"\(algorithm.rawValue)\"}", String(data: jws.header.data(), encoding: .utf8))
         XCTAssertEqual(message, String(data: jws.payload.data(), encoding: .utf8))
 
-        let signer = Signer(signingAlgorithm: algorithm, key: signingKey)!
+        let signer = Signer(signatureAlgorithm: algorithm, key: signingKey)!
         let signature = try! signer.sign(header: JWSHeader(algorithm: algorithm), payload: Payload(message.data(using: .utf8)!))
         XCTAssertEqual(jws.signature.data(), signature)
     }
@@ -39,12 +39,12 @@ class JWSHMACTests: HMACCryptoTestCase {
     private func _testHMACSerializationValidationAndDeserialization(algorithm: SignatureAlgorithm) {
         let header = JWSHeader(algorithm: algorithm)
         let payload = Payload(message.data(using: .utf8)!)
-        let signer = Signer(signingAlgorithm: algorithm, key: signingKey)!
+        let signer = Signer(signatureAlgorithm: algorithm, key: signingKey)!
         let jws = try! JWS(header: header, payload: payload, signer: signer)
         let compactSerializedJWS = jws.compactSerializedString
 
         let secondJWS = try! JWS(compactSerialization: compactSerializedJWS)
-        let verifier = Verifier(verifyingAlgorithm: algorithm, key: signingKey)
+        let verifier = Verifier(signatureAlgorithm: algorithm, key: signingKey)
 
         XCTAssertTrue(secondJWS.isValid(for: verifier!))
         XCTAssertEqual(message, String(data: secondJWS.payload.data(), encoding: .utf8))

--- a/Tests/JWSRSATests.swift
+++ b/Tests/JWSRSATests.swift
@@ -91,7 +91,7 @@ class JWSRSATests: RSACryptoTestCase {
         XCTAssertEqual(String(data: jws.header.data(), encoding: .utf8), "{\"alg\":\"\(algorithm.rawValue)\"}")
         XCTAssertEqual(String(data: jws.payload.data(), encoding: .utf8), "The true sign of intelligence is not knowledge but imagination.")
 
-        let signer = Signer(signingAlgorithm: algorithm, key: privateKeyAlice2048!)!
+        let signer = Signer(signatureAlgorithm: algorithm, key: privateKeyAlice2048!)!
         let signature = try! signer.sign(header: JWSHeader(algorithm: algorithm), payload: Payload(message.data(using: .utf8)!))
         XCTAssertEqual(jws.signature.data(), signature)
     }
@@ -107,12 +107,12 @@ class JWSRSATests: RSACryptoTestCase {
             header.kid = "kid"
         }
         let payload = Payload(message.data(using: .utf8)!)
-        let signer = Signer(signingAlgorithm: algorithm, key: privateKeyAlice2048!)!
+        let signer = Signer(signatureAlgorithm: algorithm, key: privateKeyAlice2048!)!
         let jws = try! JWS(header: header, payload: payload, signer: signer)
         let compactSerializedJWS = jws.compactSerializedString
 
         let secondJWS = try! JWS(compactSerialization: compactSerializedJWS)
-        let verifier = Verifier(verifyingAlgorithm: algorithm, key: publicKeyAlice2048!)
+        let verifier = Verifier(signatureAlgorithm: algorithm, key: publicKeyAlice2048!)
 
         XCTAssertTrue(secondJWS.isValid(for: verifier!))
         XCTAssertEqual(String(data: secondJWS.payload.data(), encoding: .utf8), "The true sign of intelligence is not knowledge but imagination.")

--- a/Tests/JWSValidationTests.swift
+++ b/Tests/JWSValidationTests.swift
@@ -29,7 +29,7 @@ class JWSValidationTests: RSACryptoTestCase {
     func testValidatesWithExplicitVerifier() {
         let jws = try! JWS(compactSerialization: compactSerializedJWSRS512Const)
 
-        let verifier = Verifier(verifyingAlgorithm: .RS512, key: publicKeyAlice2048!)!
+        let verifier = Verifier(signatureAlgorithm: .RS512, key: publicKeyAlice2048!)!
 
         XCTAssertNoThrow(try jws.validate(using: verifier))
     }
@@ -37,7 +37,7 @@ class JWSValidationTests: RSACryptoTestCase {
     func testValidatesWithExplicitVerifierReturnsJWS() {
         let jws = try! JWS(compactSerialization: compactSerializedJWSRS512Const)
 
-        let verifier = Verifier(verifyingAlgorithm: .RS512, key: publicKeyAlice2048!)!
+        let verifier = Verifier(signatureAlgorithm: .RS512, key: publicKeyAlice2048!)!
 
         let returnedJWS = try! jws.validate(using: verifier)
 
@@ -47,7 +47,7 @@ class JWSValidationTests: RSACryptoTestCase {
     func testValidatesWithExplicitVerifierCatchesWrongVerifierAlgorithm() {
         let jws = try! JWS(compactSerialization: compactSerializedJWSRS512Const)
 
-        let verifier = Verifier(verifyingAlgorithm: .RS256, key: publicKeyAlice2048!)!
+        let verifier = Verifier(signatureAlgorithm: .RS256, key: publicKeyAlice2048!)!
 
         XCTAssertThrowsError(try jws.validate(using: verifier), "verifying with wrong verifier algorithm") { error in
             XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.signingAlgorithmMismatch)
@@ -60,7 +60,7 @@ class JWSValidationTests: RSACryptoTestCase {
 
         let jws = try! JWS(compactSerialization: malformedSerialization)
 
-        let verifier = Verifier(verifyingAlgorithm: .RS512, key: publicKeyAlice2048!)!
+        let verifier = Verifier(signatureAlgorithm: .RS512, key: publicKeyAlice2048!)!
 
         XCTAssertThrowsError(try jws.validate(using: verifier), "verifying with wrong header algorithm") { error in
             XCTAssertEqual(error as! JOSESwiftError, JOSESwiftError.signingAlgorithmMismatch)
@@ -86,7 +86,7 @@ class JWSValidationTests: RSACryptoTestCase {
             return
         }
 
-        let verifier = Verifier(verifyingAlgorithm: .RS512, key: SecKeyCopyPublicKey(key)!)!
+        let verifier = Verifier(signatureAlgorithm: .RS512, key: SecKeyCopyPublicKey(key)!)!
 
         XCTAssertThrowsError(try jws.validate(using: verifier))
     }
@@ -97,7 +97,7 @@ class JWSValidationTests: RSACryptoTestCase {
 
         let jws = try! JWS(compactSerialization: malformedSerialization)
 
-        let verifier = Verifier(verifyingAlgorithm: .RS512, key: publicKeyAlice2048!)!
+        let verifier = Verifier(signatureAlgorithm: .RS512, key: publicKeyAlice2048!)!
 
         XCTAssertThrowsError(try jws.validate(using: verifier))
     }
@@ -105,7 +105,7 @@ class JWSValidationTests: RSACryptoTestCase {
     func testIsValidWithExplicitVerifier() {
         let jws = try! JWS(compactSerialization: compactSerializedJWSRS512Const)
 
-        let verifier = Verifier(verifyingAlgorithm: .RS512, key: publicKeyAlice2048!)
+        let verifier = Verifier(signatureAlgorithm: .RS512, key: publicKeyAlice2048!)
 
         XCTAssertTrue(jws.isValid(for: verifier!))
     }
@@ -116,7 +116,7 @@ class JWSValidationTests: RSACryptoTestCase {
 
         let jws = try! JWS(compactSerialization: malformedSerialization)
 
-        let verifier = Verifier(verifyingAlgorithm: .RS512, key: publicKeyAlice2048!)
+        let verifier = Verifier(signatureAlgorithm: .RS512, key: publicKeyAlice2048!)
 
         XCTAssertFalse(jws.isValid(for: verifier!))
     }
@@ -127,7 +127,7 @@ class JWSValidationTests: RSACryptoTestCase {
 
         let jws = try! JWS(compactSerialization: malformedSerialization)
 
-        let verifier = Verifier(verifyingAlgorithm: .RS512, key: publicKeyAlice2048!)
+        let verifier = Verifier(signatureAlgorithm: .RS512, key: publicKeyAlice2048!)
 
         XCTAssertFalse(jws.isValid(for: verifier!))
     }
@@ -135,7 +135,7 @@ class JWSValidationTests: RSACryptoTestCase {
     func testIsValidWithExplicitVerifierIsFalseForWrongKey() {
         let jws = try! JWS(compactSerialization: compactSerializedJWSRS512Const)
 
-        let verifier = Verifier(verifyingAlgorithm: .RS512, key: publicKey4096!)
+        let verifier = Verifier(signatureAlgorithm: .RS512, key: publicKey4096!)
 
         XCTAssertFalse(jws.isValid(for: verifier!))
     }
@@ -143,7 +143,7 @@ class JWSValidationTests: RSACryptoTestCase {
     func testIsValidWithExplicitVerifierCatchesWrongVerifierAlgorithm() {
         let jws = try! JWS(compactSerialization: compactSerializedJWSRS512Const)
 
-        let verifier = Verifier(verifyingAlgorithm: .RS256, key: publicKeyAlice2048!)!
+        let verifier = Verifier(signatureAlgorithm: .RS256, key: publicKeyAlice2048!)!
 
         XCTAssertFalse(jws.isValid(for: verifier))
     }
@@ -154,7 +154,7 @@ class JWSValidationTests: RSACryptoTestCase {
 
         let jws = try! JWS(compactSerialization: malformedSerialization)
 
-        let verifier = Verifier(verifyingAlgorithm: .RS512, key: publicKeyAlice2048!)!
+        let verifier = Verifier(signatureAlgorithm: .RS512, key: publicKeyAlice2048!)!
 
         XCTAssertFalse(jws.isValid(for: verifier))
     }

--- a/Tests/RSADecryptionTests.swift
+++ b/Tests/RSADecryptionTests.swift
@@ -175,7 +175,7 @@ class RSADecryptionTests: RSACryptoTestCase {
         for algorithm in keyManagementModeAlgorithms {
             let ciphertext = Data(count: 300)
             XCTAssertThrowsError(try RSA.decrypt(ciphertext, with: privateKeyAlice2048, and: algorithm)) { (error: Error) in
-                XCTAssertEqual(error as? RSAError, RSAError.cipherTextLenghtNotSatisfied)
+                XCTAssertEqual(error as? RSAError, RSAError.cipherTextLengthNotSatisfied)
             }
         }
     }
@@ -189,7 +189,7 @@ class RSADecryptionTests: RSACryptoTestCase {
         for algorithm in keyManagementModeAlgorithms {
             let ciphertext = Data(count: 0)
             XCTAssertThrowsError(try RSA.decrypt(ciphertext, with: privateKeyAlice2048, and: algorithm)) { (error: Error) in
-                XCTAssertEqual(error as? RSAError, RSAError.cipherTextLenghtNotSatisfied)
+                XCTAssertEqual(error as? RSAError, RSAError.cipherTextLengthNotSatisfied)
             }
         }
     }
@@ -207,7 +207,7 @@ class RSADecryptionTests: RSACryptoTestCase {
             XCTAssertThrowsError(try RSA.decrypt(testMessage, with: privateKeyAlice2048, and: algorithm)) { (error: Error) in
                 // Should throw "decryption failed", but
                 // should _not_ throw cipherTextLenghtNotSatisfied
-                XCTAssertNotEqual(error as? RSAError, RSAError.cipherTextLenghtNotSatisfied)
+                XCTAssertNotEqual(error as? RSAError, RSAError.cipherTextLengthNotSatisfied)
             }
         }
     }
@@ -223,7 +223,7 @@ class RSADecryptionTests: RSACryptoTestCase {
 
         for algorithm in keyManagementModeAlgorithms {
             XCTAssertThrowsError(try RSA.decrypt(testMessage, with: privateKeyAlice2048, and: algorithm)) { (error: Error) in
-                XCTAssertEqual(error as? RSAError, RSAError.cipherTextLenghtNotSatisfied)
+                XCTAssertEqual(error as? RSAError, RSAError.cipherTextLengthNotSatisfied)
             }
         }
     }
@@ -239,7 +239,7 @@ class RSADecryptionTests: RSACryptoTestCase {
 
         for algorithm in keyManagementModeAlgorithms {
             XCTAssertThrowsError(try RSA.decrypt(testMessage, with: privateKeyAlice2048, and: algorithm)) { (error: Error) in
-                XCTAssertEqual(error as? RSAError, RSAError.cipherTextLenghtNotSatisfied)
+                XCTAssertEqual(error as? RSAError, RSAError.cipherTextLengthNotSatisfied)
             }
         }
     }

--- a/Tests/RSAEncryptionTests.swift
+++ b/Tests/RSAEncryptionTests.swift
@@ -28,7 +28,7 @@ import XCTest
 extension RSAError: Equatable {
     public static func == (lhs: RSAError, rhs: RSAError) -> Bool {
         switch (lhs, rhs) {
-        case (.cipherTextLenghtNotSatisfied, .cipherTextLenghtNotSatisfied):
+        case (.cipherTextLengthNotSatisfied, .cipherTextLengthNotSatisfied):
             return true
         case (.plainTextLengthNotSatisfied, .plainTextLengthNotSatisfied):
             return true


### PR DESCRIPTION
Updates the naming to be more in line with [RFC-7518](https://datatracker.ietf.org/doc/html/rfc7518#section-3) which uses the terminology "Cryptographic Algorithms for Digital Signatures and MACs". I abbreviates this to the slightly incorrect but short and still understandable (imo) `signatureAlgorithm`. Before we had `signingAlgorithm` and `verifyingAlgorithm` which were two different names for the same thing. 

JWE Encrypter/Decrypter already use the naming as in the RFC: `keyEncryptionMode` and `contentEncryptionAlgorithm`