### PR TITLE
update `Signer` `init` argument labels in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The signer algorithm must match the header algorithm.
 ``` swift
 let privateKey: SecKey = /* ... */
 
-let signer = Signer(signingAlgorithm: .RS512, privateKey: privateKey)!
+let signer = Signer(signatureAlgorithm: .RS512, key: privateKey)!
 ```
 
 ##### Serializing


### PR DESCRIPTION
See https://github.com/airsidemobile/JOSESwift/blob/master/JOSESwift/Sources/JWS/Signer.swift#L52
```
public init?<KeyType>(signatureAlgorithm: SignatureAlgorithm, key: KeyType) {
```

I set up creating JWS-s and JWK-s based on the README and everything else went fine. Great lib!